### PR TITLE
Fix no clipping when source density is high

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Do not include stuff added by Pycharm to git.
 .idea/
 
+# Do not include this bash script to investigate sizes of pushed files
+# (From https://gist.github.com/magnetikonline/dd5837d597722c9c2d5dfa16d8efe5b9)
+gitlistobjectbysize.sh
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 # Do not include stuff added by Pycharm to git.
 .idea/
 
-# Do not include this bash script to investigate sizes of pushed files
-# (From https://gist.github.com/magnetikonline/dd5837d597722c9c2d5dfa16d8efe5b9)
-gitlistobjectbysize.sh
+# Do not include any shell scripts
+*.sh
+
+# Do not include the pointer_files directory.
+*pointer_files*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,5 @@ deploy:
     tags: true
     distributions: sdist bdist_wheel
     repo: transientskp/pyse
+git:
+  depth: false

--- a/gitlistobjectbysize.sh
+++ b/gitlistobjectbysize.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+
+# work over each commit and append all files in tree to $tempFile
+tempFile=$(mktemp)
+IFS=$'\n'
+for commitSHA1 in $(git rev-list --all); do
+	git ls-tree -r --long "$commitSHA1" >>"$tempFile"
+done
+
+# sort files by SHA1, de-dupe list and finally re-sort by filesize
+sort --key 3 "$tempFile" | \
+	uniq | \
+	sort --key 4 --numeric-sort --reverse
+
+# remove temp file
+rm "$tempFile"

--- a/nosetests_from_command_line.sh
+++ b/nosetests_from_command_line.sh
@@ -1,0 +1,2 @@
+!#/bin/bash
+nosetests --with-coverage --cover-package=sourcefinder

--- a/sourcefinder/image.py
+++ b/sourcefinder/image.py
@@ -239,7 +239,7 @@ class ImageData(object):
                     bgrow.append(False)
                     continue
                 chunk, sigma, median, num_clip_its = stats.sigma_clip(
-                    chunk, self.beam)
+                    chunk)
                 if len(chunk) == 0 or not chunk.any():
                     rmsrow.append(False)
                     bgrow.append(False)

--- a/sourcefinder/stats.py
+++ b/sourcefinder/stats.py
@@ -69,7 +69,7 @@ def sigma_clip(data, kappa=2.0, max_iter=100,
 
     if limit is not None:
         std_corr_for_clipping_bias = fsolve(find_true_std, std,
-                              args=(limit, std))[0]
+                                            args=(limit, std))[0]
     else:
         std_corr_for_clipping_bias = std
 

--- a/sourcefinder/stats.py
+++ b/sourcefinder/stats.py
@@ -25,7 +25,7 @@ def indep_pixels(N, beam):
     correlated_area = 0.25 * numpy.pi * corlengthlong * corlengthshort
     return N / correlated_area
 
-def sigma_clip(data, beam, kappa=2.0, max_iter=100,
+def sigma_clip(data, kappa=2.0, max_iter=100,
                centref=numpy.median, distf=numpy.var, my_iterations=0, limit=None):
     """Iterative clipping
 
@@ -58,8 +58,7 @@ def sigma_clip(data, beam, kappa=2.0, max_iter=100,
         data = data.compressed()
     centre = centref(data)
     N = numpy.size(data)
-    N_indep = indep_pixels(N, beam)
-    if N_indep < 1:
+    if N < 1:
         # This chunk is too small for processing; return an empty array.
         return numpy.array([]), 0, 0, 0
 
@@ -79,7 +78,7 @@ def sigma_clip(data, beam, kappa=2.0, max_iter=100,
 
     if len(newdata) != len(data) and len(newdata) > 0:
         my_iterations += 1
-        return sigma_clip(newdata, beam, kappa, max_iter, centref, distf,
+        return sigma_clip(newdata, kappa, max_iter, centref, distf,
                           my_iterations, limit=limit)
     else:
         return newdata, std_corr_for_clipping_bias, centre, my_iterations

--- a/sourcefinder/stats.py
+++ b/sourcefinder/stats.py
@@ -14,18 +14,6 @@ from .utils import calculate_correlation_lengths
 
 # CODE & NUMBER HANDLING ROUTINES
 #
-def var_helper(N):
-    """Correct for the fact the rms noise is computed from a clipped
-    distribution.
-
-    That noise will always be lower than the noise from the complete
-    distribution.  The correction factor is a function of the computed
-    rms noise only.
-    """
-    term1 = numpy.sqrt(2. * numpy.pi) * erf(N / numpy.sqrt(2.))
-    term2 = 2. * N * numpy.exp(-N ** 2 / 2.)
-    return term1 / (term1 - term2)
-
 def find_true_std(sigma, clip_limit, clipped_std):
     help1 = clip_limit/(sigma*numpy.sqrt(2))
     help2 = numpy.sqrt(2*numpy.pi)*erf(help1)

--- a/sourcefinder/stats.py
+++ b/sourcefinder/stats.py
@@ -19,11 +19,11 @@ def find_true_std(sigma, clip_limit, clipped_std):
     return sigma**2*(help2-2*numpy.sqrt(2)*help1*numpy.exp(-help1**2))-clipped_std**2*help2
 
 
-def indep_pixels(N, beam):
+def indep_pixels(n, beam):
     corlengthlong, corlengthshort = calculate_correlation_lengths(
         beam[0], beam[1])
     correlated_area = 0.25 * numpy.pi * corlengthlong * corlengthshort
-    return N / correlated_area
+    return n / correlated_area
 
 
 def sigma_clip(data, kappa=2.0, max_iter=100,
@@ -58,8 +58,8 @@ def sigma_clip(data, kappa=2.0, max_iter=100,
     if isinstance(data, MaskedArray):
         data = data.compressed()
     centre = centref(data)
-    N = numpy.size(data)
-    if N < 1:
+    n = numpy.size(data)
+    if n < 1:
         # This chunk is too small for processing; return an empty array.
         return numpy.array([]), 0, 0, 0
 

--- a/sourcefinder/stats.py
+++ b/sourcefinder/stats.py
@@ -79,13 +79,7 @@ def sigma_clip(data, beam, kappa=2.0, max_iter=100,
     # already built in, N being the number of pixels. So, we are
     # going to remove that and replace it by N_indep/(N_indep-1)
     clipped_var = distf(data) * (N - 1.) * N_indep / (N * (N_indep - 1.))
-    # unbiased_var = corr_clip * clipped_var
 
-    # There is an extra factor c4 needed to get a unbiased standard
-    # deviation, unbiased if we disregard clipping bias, see
-    # http://en.wikipedia.org/wiki/Unbiased_estimation_of_standard_deviation\
-    #         #Results_for_the_normal_distribution
-    # c4 = 1. - 0.25 / N_indep - 0.21875 / N_indep ** 2
     std_corr_for_limited_sample_size = numpy.sqrt(clipped_var)
 
     if limit is not None:

--- a/sourcefinder/stats.py
+++ b/sourcefinder/stats.py
@@ -88,8 +88,6 @@ def sigma_clip(data, beam, kappa=2.0, max_iter=100,
     c4 = 1. - 0.25 / N_indep - 0.21875 / N_indep ** 2
     std_corr_for_limited_sample_size = numpy.sqrt(clipped_var) / c4
     limit = kappa * std_corr_for_limited_sample_size
-    unbiased_std = fsolve(find_true_std, std_corr_for_limited_sample_size,
-                          args=(limit, std_corr_for_limited_sample_size))[0]
 
     newdata = data.compress(abs(data - centre) <= limit)
 
@@ -98,4 +96,6 @@ def sigma_clip(data, beam, kappa=2.0, max_iter=100,
         return sigma_clip(newdata, beam, kappa, max_iter, centref, distf,
                           my_iterations)
     else:
+        unbiased_std = fsolve(find_true_std, std_corr_for_limited_sample_size,
+                              args=(limit, std_corr_for_limited_sample_size))[0]
         return newdata, unbiased_std, centre, my_iterations

--- a/sourcefinder/stats.py
+++ b/sourcefinder/stats.py
@@ -85,8 +85,8 @@ def sigma_clip(data, beam, kappa=2.0, max_iter=100,
     # deviation, unbiased if we disregard clipping bias, see
     # http://en.wikipedia.org/wiki/Unbiased_estimation_of_standard_deviation\
     #         #Results_for_the_normal_distribution
-    c4 = 1. - 0.25 / N_indep - 0.21875 / N_indep ** 2
-    std_corr_for_limited_sample_size = numpy.sqrt(clipped_var) / c4
+    # c4 = 1. - 0.25 / N_indep - 0.21875 / N_indep ** 2
+    std_corr_for_limited_sample_size = numpy.sqrt(clipped_var)
 
     if limit is not None:
         std_corr_for_clipping_bias = fsolve(find_true_std, std_corr_for_limited_sample_size,

--- a/sourcefinder/stats.py
+++ b/sourcefinder/stats.py
@@ -25,6 +25,7 @@ def indep_pixels(N, beam):
     correlated_area = 0.25 * numpy.pi * corlengthlong * corlengthshort
     return N / correlated_area
 
+
 def sigma_clip(data, kappa=2.0, max_iter=100,
                centref=numpy.median, distf=numpy.var, my_iterations=0, limit=None):
     """Iterative clipping

--- a/sourcefinder/stats.py
+++ b/sourcefinder/stats.py
@@ -65,13 +65,13 @@ def sigma_clip(data, beam, kappa=2.0, max_iter=100,
 
     clipped_var = distf(data)
 
-    std_corr_for_limited_sample_size = numpy.sqrt(clipped_var)
+    std = numpy.sqrt(clipped_var)
 
     if limit is not None:
-        std_corr_for_clipping_bias = fsolve(find_true_std, std_corr_for_limited_sample_size,
-                              args=(limit, std_corr_for_limited_sample_size))[0]
+        std_corr_for_clipping_bias = fsolve(find_true_std, std,
+                              args=(limit, std))[0]
     else:
-        std_corr_for_clipping_bias = std_corr_for_limited_sample_size
+        std_corr_for_clipping_bias = std
 
     limit = kappa * std_corr_for_clipping_bias
 

--- a/sourcefinder/stats.py
+++ b/sourcefinder/stats.py
@@ -63,10 +63,7 @@ def sigma_clip(data, beam, kappa=2.0, max_iter=100,
         # This chunk is too small for processing; return an empty array.
         return numpy.array([]), 0, 0, 0
 
-    # distf=numpy.var is a sample variance with the factor N/(N-1)
-    # already built in, N being the number of pixels. So, we are
-    # going to remove that and replace it by N_indep/(N_indep-1)
-    clipped_var = distf(data) * (N - 1.) * N_indep / (N * (N_indep - 1.))
+    clipped_var = distf(data)
 
     std_corr_for_limited_sample_size = numpy.sqrt(clipped_var)
 

--- a/sourcefinder/stats.py
+++ b/sourcefinder/stats.py
@@ -6,7 +6,6 @@ variances used by the TKP sourcefinder.
 import numpy
 from numpy.ma import MaskedArray
 from scipy.special import erf
-from scipy.special import erfcinv
 from scipy.optimize import fsolve
 
 from .utils import calculate_correlation_lengths

--- a/sourcefinder/stats.py
+++ b/sourcefinder/stats.py
@@ -18,6 +18,7 @@ def find_true_std(sigma, clip_limit, clipped_std):
     help2 = numpy.sqrt(2*numpy.pi)*erf(help1)
     return sigma**2*(help2-2*numpy.sqrt(2)*help1*numpy.exp(-help1**2))-clipped_std**2*help2
 
+
 def indep_pixels(N, beam):
     corlengthlong, corlengthshort = calculate_correlation_lengths(
         beam[0], beam[1])

--- a/sourcefinder/stats.py
+++ b/sourcefinder/stats.py
@@ -37,7 +37,7 @@ def indep_pixels(N, beam):
     correlated_area = 0.25 * numpy.pi * corlengthlong * corlengthshort
     return N / correlated_area
 
-def sigma_clip(data, beam, kappa=1.5, max_iter=100,
+def sigma_clip(data, beam, kappa=2.0, max_iter=100,
                centref=numpy.median, distf=numpy.var, my_iterations=0):
     """Iterative clipping
 

--- a/test/data/pointer_files/GRB120422A-120429.fits
+++ b/test/data/pointer_files/GRB120422A-120429.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a235e30ac54e4d65f7ac375983d17344db953b50c84f7f93ba0e2e7c393596c9
+size 1065600

--- a/test/data/pointer_files/NCP_sample_image_1.fits
+++ b/test/data/pointer_files/NCP_sample_image_1.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7bf0cf2c000212e086aa816d293d572530485160f6e5b92c152c7938843ebc44
+size 4236480

--- a/test/data/pointer_files/SWIFT_554620-130504.fits
+++ b/test/data/pointer_files/SWIFT_554620-130504.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8a2876f482e244ad206b363e96d8dbd208355769fae4c99de6b6f552d5250fc
+size 1068480

--- a/test/data/pointer_files/corrected-all.fits
+++ b/test/data/pointer_files/corrected-all.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c977eaf67c9d6ba3cec034abee88709eebb97cbb6c8324858921674303f21841
+size 33183360

--- a/test/data/pointer_files/correlated_noise.fits
+++ b/test/data/pointer_files/correlated_noise.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8bba57396707164ef18102eb5f2bee1dc1f82847a22bd6dc95556ffbb957bd1e
+size 33560640

--- a/test/data/pointer_files/deconvolved.fits
+++ b/test/data/pointer_files/deconvolved.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63b0be876c2abed9ef6982d633c10ce03c92843f5292062b7114de75c0def06f
+size 33560640

--- a/test/data/pointer_files/model-all.fits
+++ b/test/data/pointer_files/model-all.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c1240f8ab0ece15070fc58635344e58695dbf67f6a21a573bf50a3a38679acd
+size 33183360

--- a/test/data/pointer_files/observed-all.fits
+++ b/test/data/pointer_files/observed-all.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69ab1716b7847b1371bc63758f56d258f760481198d7685528c1f736a05a06ad
+size 33183360

--- a/test/data/pointer_files/uncorrelated_noise.fits
+++ b/test/data/pointer_files/uncorrelated_noise.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51d44e83a43b7c21fb6b5d05d153df1fc9b5b906465d596df69a4a5eddc52d1f
+size 33560640


### PR DESCRIPTION
Fixes #7 

However, it involves quite an overhaul of stats.sigma_clip.
In summary, what I ran into with an artificial 4K * 4K image with 167000 sources of ~ 100 Jy on top of Gaussian noise with an std of 1 Jy is that no clipping was done at all, because the initial estimate of the std - so before any clipping- of the background noise was so high: over 19 Jy.
The dynamical clipping limit related to equation 2.22 of my thesis set kappa equal to about five, I believe, and all pixels were below that limit of kappa * 19 Jy.

Now the dynamical clipping limit ensures that any parameters derived from the clipped distribution are not biased by clipping. 
No bias is good, so when dropping the dynamical clipping limit something else is needed to correct for the clipping bias.
I could do that by solving for sigma in the transcendental equation 2.25 from my thesis, using the new module find_true_std.
(Previously var_helper was used, which combines 2.22 and 2.25, making it non-transcendental and easy to derive the correction for the clipping bias).

I set kappa=2 fixed, so there will virtually always be clipping at the limit of kappa * std.
(Note that there is a lower limit to kappa, find_true_std will not have any roots for kappa < sqrt(3), This means that equation 2.25 of my thesis does not have any solutions for D/sigma < sqrt(3), this is not so hard to prove.)

I also removed the beam properties (self.beam in image.py) from the input to stats.sigma_clip. The size of the synthesized beam was needed to make an estimate of the number of independent pixels in the subimage, but with 2.22 (dynamical clipping limit) removed from the calculations, this is no longer needed. It also appeared in corrections for biases of the variances from limited sample sizes (number of independent pixels in the subimage), but these corrections turn out to be so small for any subimage of reasonable size that they can be neglected. Same for the "c4" correction to the standard deviation.





