### PR TITLE
Fix runtimewarnings from nosetests.

### DIFF
--- a/sourcefinder/extract.py
+++ b/sourcefinder/extract.py
@@ -947,9 +947,12 @@ class Detection(object):
         self.theta_celes = Uncertain(
             (numpy.degrees(self.theta.value) + yoffset_angle) % 180,
             numpy.degrees(self.theta.error))
-        self.theta_dc_celes = Uncertain(
-            (self.theta_dc.value + yoffset_angle) % 180,
-            numpy.degrees(self.theta_dc.error))
+        if not numpy.isnan(self.theta_dc.value):
+            self.theta_dc_celes = Uncertain(
+                (self.theta_dc.value + yoffset_angle) % 180,
+                 numpy.degrees(self.theta_dc.error))
+        else:
+             self.theta_dc_celes = Uncertain(numpy.nan, numpy.nan)
 
         # Next, the axes.
         # Note that the signs of numpy.sin and numpy.cos in the

--- a/sourcefinder/fitting.py
+++ b/sourcefinder/fitting.py
@@ -93,7 +93,11 @@ def moments(data, beam, threshold=0):
         # short circuit!
         theta = 0.
     else:
-        theta = math.atan(2. * xybar / (xxbar - yybar)) / 2.
+        if xxbar!=yybar:
+            theta = math.atan(2. * xybar / (xxbar - yybar)) / 2.
+        else:
+            theta = numpy.sign(xybar) * math.pi / 4.0
+
         if theta * xybar > 0.:
             if theta < 0.:
                 theta += math.pi / 2.0


### PR DESCRIPTION
Fixes #9 

This just adds some condtionals for the case that `xxbar==yybar` in [fitting.py](https://github.com/transientskp/pyse/blob/a8310c2967bf597d265376e7e5bd8ca598bb34be/sourcefinder/fitting.py#L96) to avoid a division by zero and a nan check for `self.theta_dc.value` in [extract.py](https://github.com/transientskp/pyse/blob/a8310c2967bf597d265376e7e5bd8ca598bb34be/sourcefinder/extract.py#L950).

In this way the nosetests can be run without warnings.