### PR TITLE
Kappa sigma clipping using dask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,8 @@
 *pointer_files*
 
 # Do not include FITS files
-**/test/data/*.fits
-**/test/data/*.FITS
+**.fits
+**.FITS
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -114,3 +114,4 @@ ENV/
 
 # mypy
 .mypy_cache/
+/test/data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN docker-apt-install \
     python3-dateutil \
     python3-six \
     python3-nose \
-    python3-psutil
+    python3-psutil \
+    python3-dask
 
 ADD . /code
 WORKDIR /code

--- a/nosetests_from_command_line.sh
+++ b/nosetests_from_command_line.sh
@@ -1,2 +1,2 @@
-!#/bin/bash
+#!/usr/bin/bash
 nosetests --with-coverage --cover-package=sourcefinder

--- a/scripts/pyse
+++ b/scripts/pyse
@@ -35,6 +35,10 @@ from sourcefinder.accessors import writefits as tkp_writefits
 from sourcefinder.utility.cli import parse_monitoringlist_positions
 from sourcefinder.utils import generate_result_maps
 from six import print_
+from dask.distributed import Client
+
+if __name__ == '__main__':
+    client = Client()  #
 
 def regions(sourcelist):
     """

--- a/sourcefinder/image.py
+++ b/sourcefinder/image.py
@@ -18,7 +18,6 @@ import psutil
 import time
 import dask.array as da
 
-
 try:
     import ndimage
 except ImportError:
@@ -239,8 +238,8 @@ class ImageData(object):
         assert (len(useful_chunk) == 1)
         useful_data = da.from_array(self.data[useful_chunk[0]].data, chunks=(self.back_size_x, self.back_size_y))
 
-        mode_and_rms = useful_data.map_blocks(self.compute_mode_and_rms_of_subimages, dtype=numpy.complex64,\
-                                              chunks=(1,1)).compute()
+        mode_and_rms = useful_data.map_blocks(self.compute_mode_and_rms_of_subimages, dtype=numpy.complex64,
+                                              chunks=(1, 1)).compute()
 
         # See also similar comment below. This solution was chosen because map_blocks does not seem to be able to
         # output multiple arrays. One can however output to a complex array and take real and imaginary
@@ -258,7 +257,8 @@ class ImageData(object):
 
         return { 'bg': mode_grid, 'rms': rms_grid,}
 
-    def compute_mode_and_rms_of_subimages(self, chunk):
+    @staticmethod
+    def compute_mode_and_rms_of_subimages(chunk):
 
         # We set up a dedicated logging subchannel, as the sigmaclip loop
         # logging is very chatty:

--- a/sourcefinder/image.py
+++ b/sourcefinder/image.py
@@ -362,8 +362,12 @@ class ImageData(object):
         # same output as map_coordinates. My bad.
         # I checked, using fitsdiff, that it gives the exact same output as the original code
         # up to and including --relative-tolerance=1e-15 for INTERPOLATE_ORDER=1.
+        # It was actually quite a hassle to get the same output and the fill_value is essential
+        # in interp1d. However, for some unit tests, grid.shape=(1,1) and then it will break
+        # with "ValueError: x and y arrays must have at least 2 entries". So in that case
+        # map_coordinates should be used.
 
-        if INTERPOLATE_ORDER==1:
+        if INTERPOLATE_ORDER==1 and grid.shape[0]>1 and grid.shape[1]>1:
             x_initial = numpy.linspace(0., grid.shape[0]-1, grid.shape[0], endpoint=True)
             y_initial = numpy.linspace(0., grid.shape[1]-1, grid.shape[1], endpoint=True)
             x_sought = numpy.linspace(-0.5, -0.5 + xratio, my_xdim, endpoint=True)

--- a/sourcefinder/image.py
+++ b/sourcefinder/image.py
@@ -307,6 +307,7 @@ class ImageData(object):
         # for the rms.
         return row_of_complex_values
 
+    @timeit
     def _interpolate(self, grid, roundup=False):
         """
         Interpolate a grid to produce a map of the dimensions of the image.

--- a/sourcefinder/image.py
+++ b/sourcefinder/image.py
@@ -238,7 +238,7 @@ class ImageData(object):
         assert (len(useful_chunk) == 1)
         useful_data = da.from_array(self.data[useful_chunk[0]].data, chunks=(self.back_size_x, self.back_size_y))
 
-        mode_and_rms = useful_data.map_blocks(self.compute_mode_and_rms_of_subimages, dtype=numpy.complex64,
+        mode_and_rms = useful_data.map_blocks(ImageData.compute_mode_and_rms_of_subimages, dtype=numpy.complex64,
                                               chunks=(1, 1)).compute()
 
         # See also similar comment below. This solution was chosen because map_blocks does not seem to be able to

--- a/sourcefinder/image.py
+++ b/sourcefinder/image.py
@@ -17,8 +17,7 @@ from sourcefinder.utility.memoize import Memoize
 import psutil
 import time
 import dask.array as da
-import dask
-dask.config.set(scheduler='threads')
+
 
 try:
     import ndimage

--- a/sourcefinder/image.py
+++ b/sourcefinder/image.py
@@ -14,9 +14,9 @@ from sourcefinder import utils
 from sourcefinder.utility import containers
 from sourcefinder.utility.memoize import Memoize
 
-import psutil
 import time
 import dask.array as da
+from scipy.interpolate import interp1d
 
 try:
     import ndimage
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 #
 # Hard-coded configuration parameters; not user settable.
 #
-INTERPOLATE_ORDER = 1  # Spline order for grid interpolation
+INTERPOLATE_ORDER = 1
 MEDIAN_FILTER = 0  # If non-zero, apply a median filter of size
 # MEDIAN_FILTER to the background and RMS grids prior
 # to interpolating.
@@ -348,11 +348,7 @@ class ImageData(object):
         # Bicubic spline interpolation
         xratio = float(my_xdim) / self.back_size_x
         yratio = float(my_ydim) / self.back_size_y
-        # First arg: starting point. Second arg: ending point. Third arg:
-        # 1j * number of points. (Why is this complex? Sometimes, NumPy has an
-        # utterly baffling API...)
-        slicex = slice(-0.5, -0.5 + xratio, 1j * my_xdim)
-        slicey = slice(-0.5, -0.5 + yratio, 1j * my_ydim)
+
         my_map = numpy.ma.MaskedArray(numpy.zeros(self.data.shape),
                                       mask=self.data.mask)
 
@@ -360,9 +356,34 @@ class ImageData(object):
         # behavior
         my_map.unshare_mask()
 
-        my_map[useful_chunk[0]] = ndimage.map_coordinates(
-            grid, numpy.mgrid[slicex, slicey],
-            mode='nearest', order=INTERPOLATE_ORDER)
+        # Inspired by https://stackoverflow.com/questions/13242382/resampling-a-numpy-array-representing-an-image
+        # Should be much faster than scipy.ndimage.map_coordinates.
+        # scipy.ndimage.zoom should also be an option for speedup, but zoom dit not let me produce the exact
+        # same output as map_coordinates. My bad.
+        # I checked, using fitsdiff, that it gives the exact same output as the original code
+        # up to and including --relative-tolerance=1e-15 for INTERPOLATE_ORDER=1.
+
+        if INTERPOLATE_ORDER==1:
+            x_initial = numpy.linspace(0., grid.shape[0]-1, grid.shape[0], endpoint=True)
+            y_initial = numpy.linspace(0., grid.shape[1]-1, grid.shape[1], endpoint=True)
+            x_sought = numpy.linspace(-0.5, -0.5 + xratio, my_xdim, endpoint=True)
+            y_sought = numpy.linspace(-0.5, -0.5 + yratio, my_ydim, endpoint=True)
+
+            primary_interpolation = interp1d(y_initial, grid, kind='slinear', assume_sorted=True,
+                                             axis=1, copy=False, bounds_error=False,
+                                             fill_value=(grid[:, 0], grid[:, -1]))
+            transposed = primary_interpolation(y_sought).T
+
+            perpendicular_interpolation = interp1d(x_initial, transposed, kind='slinear', assume_sorted=True,
+                                                   axis=1, copy=False, bounds_error=False,
+                                                   fill_value=(transposed[:, 0], transposed[:, -1]))
+            my_map[useful_chunk[0]] = perpendicular_interpolation(x_sought).T
+        else:
+            slicex = slice(-0.5, -0.5 + xratio, 1j * my_xdim)
+            slicey = slice(-0.5, -0.5 + yratio, 1j * my_ydim)
+            my_map[useful_chunk[0]] = ndimage.map_coordinates(
+               grid, numpy.mgrid[slicex, slicey],
+               mode='nearest', order=INTERPOLATE_ORDER)
 
         # If the input grid was entirely masked, then the output map must
         # also be masked: there's no useful data here. We don't search for

--- a/sourcefinder/image.py
+++ b/sourcefinder/image.py
@@ -816,12 +816,11 @@ class ImageData(object):
         RMS_FILTER = 0.001
         clipped_data = numpy.ma.where(
             (self.data_bgsubbed > analysisthresholdmap) &
-            (self.rmsmap >= (RMS_FILTER * numpy.ma.median(self.rmsmap))),
+            (self.rmsmap >= (RMS_FILTER * numpy.ma.median(self.grids["rms"]))),
             1, 0
         ).filled(fill_value=0)
         labelled_data, num_labels = ndimage.label(clipped_data,
                                                   STRUCTURING_ELEMENT)
-
         labels_below_det_thr, labels_above_det_thr = [], []
         if num_labels > 0:
             # Select the labels of the islands above the analysis threshold


### PR DESCRIPTION
This implements paralllellisation of kappa, sigma clipping in PySE using Dask. 
The output is numerically equal to the output from the Ray implementation, which is numerically equal to the output of the single threaded implementation of the `Fix-no-clipping-when-source-density-is-high` branch.

For the optimum workload per thread, the Dask implementation completed clipping in 2.0s on my laptop. For the Ray implementation it took 3.0s.

However, on my more powerful pc the relative difference became somewhat smaller.