### PR TITLE
Faster interpolation than scipy.ndimage.map_coordinates for the linear case.

### DIFF
--- a/sourcefinder/image.py
+++ b/sourcefinder/image.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 #
 # Hard-coded configuration parameters; not user settable.
 #
-INTERPOLATE_ORDER = 1  # Spline order for grid interpolation
+INTERPOLATE_ORDER = 1
 MEDIAN_FILTER = 0  # If non-zero, apply a median filter of size
 # MEDIAN_FILTER to the background and RMS grids prior
 # to interpolating.
@@ -348,11 +348,6 @@ class ImageData(object):
         # Bicubic spline interpolation
         xratio = float(my_xdim) / self.back_size_x
         yratio = float(my_ydim) / self.back_size_y
-        # First arg: starting point. Second arg: ending point. Third arg:
-        # 1j * number of points. (Why is this complex? Sometimes, NumPy has an
-        # utterly baffling API...)
-        # slicex = slice(-0.5, -0.5 + xratio, 1j * my_xdim)
-        # slicey = slice(-0.5, -0.5 + yratio, 1j * my_ydim)
 
         my_map = numpy.ma.MaskedArray(numpy.zeros(self.data.shape),
                                       mask=self.data.mask)
@@ -365,25 +360,30 @@ class ImageData(object):
         # Should be much faster than scipy.ndimage.map_coordinates.
         # scipy.ndimage.zoom should also be an option for speedup, but zoom dit not let me produce the exact
         # same output as map_coordinates. My bad.
+        # I checked, using fitsdiff, that it gives the exact same output as the original code
+        # up to and including --relative-tolerance=1e-15 for INTERPOLATE_ORDER=1.
 
-        x_initial = numpy.linspace(0., grid.shape[0]-1, grid.shape[0], endpoint=True)
-        y_initial = numpy.linspace(0., grid.shape[1]-1, grid.shape[1], endpoint=True)
-        x_sought = numpy.linspace(-0.5, -0.5 + xratio, my_xdim, endpoint=True)
-        y_sought = numpy.linspace(-0.5, -0.5 + yratio, my_ydim, endpoint=True)
+        if INTERPOLATE_ORDER==1:
+            x_initial = numpy.linspace(0., grid.shape[0]-1, grid.shape[0], endpoint=True)
+            y_initial = numpy.linspace(0., grid.shape[1]-1, grid.shape[1], endpoint=True)
+            x_sought = numpy.linspace(-0.5, -0.5 + xratio, my_xdim, endpoint=True)
+            y_sought = numpy.linspace(-0.5, -0.5 + yratio, my_ydim, endpoint=True)
 
-        primary_interpolation = interp1d(y_initial, grid, kind='slinear', assume_sorted=True,
-                                         axis=1, copy=False, bounds_error=False,
-                                         fill_value=(grid[:, 0], grid[:, -1]))
-        transposed = primary_interpolation(y_sought).T
+            primary_interpolation = interp1d(y_initial, grid, kind='slinear', assume_sorted=True,
+                                             axis=1, copy=False, bounds_error=False,
+                                             fill_value=(grid[:, 0], grid[:, -1]))
+            transposed = primary_interpolation(y_sought).T
 
-        perpendicular_interpolation = interp1d(x_initial, transposed, kind='slinear', assume_sorted=True,
-                                               axis=1, copy=False, bounds_error=False,
-                                               fill_value=(transposed[:, 0], transposed[:, -1]))
-        my_map[useful_chunk[0]] = perpendicular_interpolation(x_sought).T
-
-        # my_map[useful_chunk[0]] = ndimage.map_coordinates(
-        #    grid, numpy.mgrid[slicex, slicey],
-        #    mode='nearest', order=INTERPOLATE_ORDER)
+            perpendicular_interpolation = interp1d(x_initial, transposed, kind='slinear', assume_sorted=True,
+                                                   axis=1, copy=False, bounds_error=False,
+                                                   fill_value=(transposed[:, 0], transposed[:, -1]))
+            my_map[useful_chunk[0]] = perpendicular_interpolation(x_sought).T
+        else:
+            slicex = slice(-0.5, -0.5 + xratio, 1j * my_xdim)
+            slicey = slice(-0.5, -0.5 + yratio, 1j * my_ydim)
+            my_map[useful_chunk[0]] = ndimage.map_coordinates(
+               grid, numpy.mgrid[slicex, slicey],
+               mode='nearest', order=INTERPOLATE_ORDER)
 
         # If the input grid was entirely masked, then the output map must
         # also be masked: there's no useful data here. We don't search for


### PR DESCRIPTION
`scipy.ndimage.map_coordinates` is used to interpolate the grid values of the background mode and rms to the entire image.
Default this is done using bilinear interpolation.
For that case much faster solutions are available.

One of the answers to this [SO question](https://stackoverflow.com/questions/13242382/resampling-a-numpy-array-representing-an-image) includes these four lines of code:
```
    f = interp.interp1d(y, im, kind='linear')
    temp = f(new_y)
    f = interp.interp1d(x, temp.T, kind='linear')
    new_im = f(new_x).T
```
This is more than three times faster than `scipy.ndimage.map_coordinates` for linear interpolation. 
`scipy.ndimage.zoom` should also be an option for speedup, but even after extensive tweaking of the `zoom` parameters I could not produce the exact same output as `map_coordinates`. My bad.

(One might want to retain the option to apply other interpolation orders, I do not see its use, not accommodated for here)