### PR TITLE
Accelerate label islands

### DIFF
--- a/scripts/pyse
+++ b/scripts/pyse
@@ -35,6 +35,10 @@ from sourcefinder.accessors import writefits as tkp_writefits
 from sourcefinder.utility.cli import parse_monitoringlist_positions
 from sourcefinder.utils import generate_result_maps
 from six import print_
+from dask.distributed import Client
+
+if __name__ == '__main__':
+    client = Client()  #
 
 def regions(sourcelist):
     """

--- a/sourcefinder/image.py
+++ b/sourcefinder/image.py
@@ -794,15 +794,15 @@ class ImageData(object):
         # falling outside the circular region produced by awimager.
         RMS_FILTER = 0.001
         start_time=time.time()
-        # clipped_data = numpy.ma.where(
-        #     (self.data_bgsubbed > analysisthresholdmap) &
-        #     (self.rmsmap >= (RMS_FILTER * numpy.ma.median(self.rmsmap))),
-        #     1, 0
-        # ).filled(fill_value=0)
         clipped_data = numpy.ma.where(
-            (self.data_bgsubbed > analysisthresholdmap),
+            (self.data_bgsubbed > analysisthresholdmap) &
+            (self.rmsmap >= (RMS_FILTER * numpy.ma.median(self.grids["rms"]))),
             1, 0
         ).filled(fill_value=0)
+        # clipped_data = numpy.ma.where(
+        #     (self.data_bgsubbed > analysisthresholdmap),
+        #     1, 0
+        # ).filled(fill_value=0)
         end_clipping = time.time()
         print("clipping time amounts to {}".format(end_clipping-start_time))
         labelled_data, num_labels = ndimage.label(clipped_data,

--- a/sourcefinder/image.py
+++ b/sourcefinder/image.py
@@ -793,23 +793,13 @@ class ImageData(object):
         # which contain no usable data; for example, the parts of the image
         # falling outside the circular region produced by awimager.
         RMS_FILTER = 0.001
-        start_time=time.time()
         clipped_data = numpy.ma.where(
             (self.data_bgsubbed > analysisthresholdmap) &
             (self.rmsmap >= (RMS_FILTER * numpy.ma.median(self.grids["rms"]))),
             1, 0
         ).filled(fill_value=0)
-        # clipped_data = numpy.ma.where(
-        #     (self.data_bgsubbed > analysisthresholdmap),
-        #     1, 0
-        # ).filled(fill_value=0)
-        end_clipping = time.time()
-        print("clipping time amounts to {}".format(end_clipping-start_time))
         labelled_data, num_labels = ndimage.label(clipped_data,
                                                   STRUCTURING_ELEMENT)
-        end_labeling = time.time()
-        print("labeling time amounts to {}".format(end_labeling - end_clipping))
-        print("total time for both tasks amounts to {}".format(end_labeling - start_time))
         labels_below_det_thr, labels_above_det_thr = [], []
         if num_labels > 0:
             # Select the labels of the islands above the analysis threshold

--- a/sourcefinder/image.py
+++ b/sourcefinder/image.py
@@ -793,14 +793,23 @@ class ImageData(object):
         # which contain no usable data; for example, the parts of the image
         # falling outside the circular region produced by awimager.
         RMS_FILTER = 0.001
+        start_time=time.time()
+        # clipped_data = numpy.ma.where(
+        #     (self.data_bgsubbed > analysisthresholdmap) &
+        #     (self.rmsmap >= (RMS_FILTER * numpy.ma.median(self.rmsmap))),
+        #     1, 0
+        # ).filled(fill_value=0)
         clipped_data = numpy.ma.where(
-            (self.data_bgsubbed > analysisthresholdmap) &
-            (self.rmsmap >= (RMS_FILTER * numpy.ma.median(self.rmsmap))),
+            (self.data_bgsubbed > analysisthresholdmap),
             1, 0
         ).filled(fill_value=0)
+        end_clipping = time.time()
+        print("clipping time amounts to {}".format(end_clipping-start_time))
         labelled_data, num_labels = ndimage.label(clipped_data,
                                                   STRUCTURING_ELEMENT)
-
+        end_labeling = time.time()
+        print("labeling time amounts to {}".format(end_labeling - end_clipping))
+        print("total time for both tasks amounts to {}".format(end_labeling - start_time))
         labels_below_det_thr, labels_above_det_thr = [], []
         if num_labels > 0:
             # Select the labels of the islands above the analysis threshold


### PR DESCRIPTION
Originally intended as a branch to make connected component labeling (ccl) run faster using the pyvips/libvips library.

Then it turned out that segmentation (thresholding) was way more computationally expensive than ccl.

And more than half of the time to perform the segmentation was devoted to computing a median of the noisemap, i.e. a median over the entire image. Way too expensive and does not make sense, since these are mostly interpolated values. Why include them in computing the median? Now we use only the grid values, which is much faster.