### PR TITLE
Fudge max pix and maximum pixel method variance should only be called once per image

### DIFF
--- a/sourcefinder/extract.py
+++ b/sourcefinder/extract.py
@@ -294,7 +294,7 @@ class ParamSet(MutableMapping):
         """ """
         return list(self.values.keys())
 
-    def calculate_errors(self, noise, beam, max_pix_variance_factor, correlation_lengths, threshold):
+    def calculate_errors(self, noise, max_pix_variance_factor, correlation_lengths, threshold):
         """Calculate positional errors
 
         Uses _condon_formulae() if this object is based on a Gaussian fit,
@@ -302,16 +302,16 @@ class ParamSet(MutableMapping):
         """
 
         if self.gaussian:
-            return self._condon_formulae(noise, beam, correlation_lengths)
+            return self._condon_formulae(noise, correlation_lengths)
         elif self.moments:
             if not threshold:
                 threshold = 0
-            return self._error_bars_from_moments(noise, beam, max_pix_variance_factor, correlation_lengths,
+            return self._error_bars_from_moments(noise, max_pix_variance_factor, correlation_lengths,
                                                  threshold)
         else:
             return False
 
-    def _condon_formulae(self, noise, beam, correlation_lengths):
+    def _condon_formulae(self, noise, correlation_lengths):
         """Returns the errors on parameters from Gaussian fits according to
         the Condon (PASP 109, 166 (1997)) formulae.
 
@@ -402,7 +402,7 @@ class ParamSet(MutableMapping):
 
         return self
 
-    def _error_bars_from_moments(self, noise, beam, max_pix_variance_factor, correlation_lengths,
+    def _error_bars_from_moments(self, noise, max_pix_variance_factor, correlation_lengths,
                                  threshold):
         """Provide reasonable error estimates from the moments"""
 
@@ -725,7 +725,7 @@ def source_profile_and_errors(data, threshold, noise,
 
     param["flux"] = (numpy.pi * param["peak"] * param["semimajor"] *
                      param["semiminor"] / beamsize)
-    param.calculate_errors(noise, beam, max_pix_variance_factor, correlation_lengths, threshold)
+    param.calculate_errors(noise, max_pix_variance_factor, correlation_lengths, threshold)
     param.deconvolve_from_clean_beam(beam)
 
     # Calculate residuals

--- a/sourcefinder/fitting.py
+++ b/sourcefinder/fitting.py
@@ -235,7 +235,7 @@ def fitgaussian(pixels, params, fixed=None, maxfev=0):
     return results
 
 
-def goodness_of_fit(masked_residuals, noise, beam):
+def goodness_of_fit(masked_residuals, noise, correlation_lengths):
     """
     Calculates the goodness-of-fit values, `chisq` and `reduced_chisq`.
 
@@ -271,7 +271,15 @@ def goodness_of_fit(masked_residuals, noise, beam):
         noise (float): An estimate of the noise level. Could also be set to
             a masked numpy array matching the data, for per-pixel noise
             estimates.
-        beam (tuple): Beam parameters
+
+        correlation_lengths(tuple): Tuple of two floats describing the distance along the semimajor
+                                    and semiminor axes of the clean beam beyond which noise
+                                    is assumed uncorrelated. Some background: Aperture synthesis imaging
+                                    yields noise that is partially correlated
+                                    over the entire image. This has a considerable effect on error
+                                    estimates. We approximate this by considering all noise within the
+                                    correlation length completely correlated and beyond that completely
+                                    uncorrelated.
 
     Returns:
         tuple: chisq, reduced_chisq
@@ -280,6 +288,6 @@ def goodness_of_fit(masked_residuals, noise, beam):
     gauss_resid_normed = (masked_residuals / noise).compressed()
     chisq = numpy.sum(gauss_resid_normed * gauss_resid_normed)
     n_fitted_pix = len(masked_residuals.compressed().ravel())
-    n_indep_pix = indep_pixels(n_fitted_pix, beam)
+    n_indep_pix = indep_pixels(n_fitted_pix, correlation_lengths)
     reduced_chisq = chisq / n_indep_pix
     return chisq, reduced_chisq

--- a/sourcefinder/fitting.py
+++ b/sourcefinder/fitting.py
@@ -26,6 +26,10 @@ def moments(data, fudge_max_pix_factor, beamsize, threshold=0):
 
         beamsize(float): The FWHM size of the clean beam
 
+        threshold(float): source parameters like the semimajor and semiminor axes
+                          derived from moments can be underestimated if one does not take
+                          account of the threshold that was used to segment the source islands.
+
     Returns:
         dict: peak, total, x barycenter, y barycenter, semimajor
             axis, semiminor axis, theta

--- a/sourcefinder/fitting.py
+++ b/sourcefinder/fitting.py
@@ -14,15 +14,17 @@ from .stats import indep_pixels
 FIT_PARAMS = ('peak', 'xbar', 'ybar', 'semimajor', 'semiminor', 'theta')
 
 
-def moments(data, beam, fudge_max_pix_factor, threshold=0):
+def moments(data, fudge_max_pix_factor, beamsize, threshold=0):
     """Calculate source positional values using moments
 
     Args:
 
         data (numpy.ndarray): Actual 2D image data
 
-        beam (3-tuple): beam (psf) information, with semi-major and
-            semi-minor axes
+        fudge_max_pix_factor(float): Correct for the underestimation of the peak
+                                     by taking the maximum pixel value.
+
+        beamsize(float): The FWHM size of the clean beam
 
     Returns:
         dict: peak, total, x barycenter, y barycenter, semimajor
@@ -39,7 +41,6 @@ def moments(data, beam, fudge_max_pix_factor, threshold=0):
     # Are we fitting a -ve or +ve Gaussian?
     if data.mean() >= 0:
         # The peak is always underestimated when you take the highest pixel.
-        # peak = data.max() * utils.fudge_max_pix(beam[0], beam[1], beam[2])
         peak = data.max() * fudge_max_pix_factor
     else:
         peak = data.min()
@@ -54,7 +55,6 @@ def moments(data, beam, fudge_max_pix_factor, threshold=0):
 
     working1 = (xxbar + yybar) / 2.0
     working2 = math.sqrt(((xxbar - yybar) / 2) ** 2 + xybar ** 2)
-    beamsize = utils.calculate_beamsize(beam[0], beam[1])
 
     # Some problems arise with the sqrt of (working1-working2) when they are
     # equal, this happens with islands that have a thickness of only one pixel

--- a/sourcefinder/fitting.py
+++ b/sourcefinder/fitting.py
@@ -14,7 +14,7 @@ from .stats import indep_pixels
 FIT_PARAMS = ('peak', 'xbar', 'ybar', 'semimajor', 'semiminor', 'theta')
 
 
-def moments(data, beam, threshold=0):
+def moments(data, beam, fudge_max_pix_factor, threshold=0):
     """Calculate source positional values using moments
 
     Args:
@@ -39,7 +39,8 @@ def moments(data, beam, threshold=0):
     # Are we fitting a -ve or +ve Gaussian?
     if data.mean() >= 0:
         # The peak is always underestimated when you take the highest pixel.
-        peak = data.max() * utils.fudge_max_pix(beam[0], beam[1], beam[2])
+        # peak = data.max() * utils.fudge_max_pix(beam[0], beam[1], beam[2])
+        peak = data.max() * fudge_max_pix_factor
     else:
         peak = data.min()
     ratio = threshold / peak

--- a/sourcefinder/image.py
+++ b/sourcefinder/image.py
@@ -878,7 +878,7 @@ class ImageData(object):
         return labels_above_det_thr, labelled_data
 
     @staticmethod
-    def fit_islands(island, fudge_max_pix_factor, max_pix_variance_factor, beamsize, fixed):
+    def fit_islands(fudge_max_pix_factor, max_pix_variance_factor, beamsize, fixed, island):
         return island.fit(fudge_max_pix_factor, max_pix_variance_factor, beamsize, fixed=fixed)
 
     @timeit
@@ -993,8 +993,7 @@ class ImageData(object):
         start_of_fitting_loop = time.time()
         with Pool(psutil.cpu_count()) as p:
             fit_islands_fixed = partial(ImageData.fit_islands, self.fudge_max_pix_factor,
-                                        self. max_pix_variance_factor, self.beamsize,
-                                        fixed=fixed)
+                                        self. max_pix_variance_factor, self.beamsize, fixed)
             fit_results = p.map(fit_islands_fixed, island_list)
         end_of_fitting_loop = time.time()
         print("Fitting took {:7.2f} seconds.".format(end_of_fitting_loop-start_of_fitting_loop))

--- a/sourcefinder/image.py
+++ b/sourcefinder/image.py
@@ -699,11 +699,9 @@ class ImageData(object):
 
         try:
             measurement, residuals = extract.source_profile_and_errors(
-                fitme,
-                threshold_at_pixel,
-                self.rmsmap[int(x), int(y)],
-                self.beam,
-                fixed=fixed
+                fitme, threshold_at_pixel,self.rmsmap[int(x), int(y)],
+                self.beam, self.fudge_max_pix_factor, self.max_pix_variance_factor,
+                self.beamsize, fixed=fixed
             )
         except ValueError:
             # Fit failed to converge

--- a/sourcefinder/image.py
+++ b/sourcefinder/image.py
@@ -701,7 +701,7 @@ class ImageData(object):
             measurement, residuals = extract.source_profile_and_errors(
                 fitme, threshold_at_pixel,self.rmsmap[int(x), int(y)],
                 self.beam, self.fudge_max_pix_factor, self.max_pix_variance_factor,
-                self.beamsize, fixed=fixed
+                self.beamsize, self.correlation_lengths, fixed=fixed
             )
         except ValueError:
             # Fit failed to converge

--- a/sourcefinder/image.py
+++ b/sourcefinder/image.py
@@ -86,6 +86,9 @@ class ImageData(object):
         self.rawdata = data  # a 2D numpy array
         self.wcs = wcs  # a utility.coordinates.wcs instance
         self.beam = beam  # tuple of (semimaj, semimin, theta)
+        self.fudge_max_pix_factor = utils.fudge_max_pix(beam[0], beam[1], beam[2])
+        self.max_pix_variance_factor = utils.maximum_pixel_method_variance(
+                           beam[0], beam[1], beam[2])
         self.clip = {}
         self.labels = {}
         self.freq_low = 1
@@ -872,8 +875,8 @@ class ImageData(object):
         return labels_above_det_thr, labelled_data
 
     @staticmethod
-    def fit_islands(island, fixed):
-        return island.fit(fixed=fixed)
+    def fit_islands(island, fudge_max_pix_factor, max_pix_variance_factor, fixed):
+        return island.fit(fudge_max_pix_factor, max_pix_variance_factor, fixed=fixed)
 
     @timeit
     def _pyse(
@@ -986,7 +989,8 @@ class ImageData(object):
         results = containers.ExtractionResults()
         start_of_fitting_loop = time.time()
         with Pool(psutil.cpu_count()) as p:
-            fit_islands_fixed = partial(ImageData.fit_islands, fixed=fixed)
+            fit_islands_fixed = partial(ImageData.fit_islands, self.fudge_max_pix_factor, self. max_pix_variance_factor,
+                                        fixed=fixed)
             fit_results = p.map(fit_islands_fixed, island_list)
         end_of_fitting_loop = time.time()
         print("Fitting took {:7.2f} seconds.".format(end_of_fitting_loop-start_of_fitting_loop))

--- a/sourcefinder/stats.py
+++ b/sourcefinder/stats.py
@@ -8,8 +8,6 @@ from numpy.ma import MaskedArray
 from scipy.special import erf
 from scipy.optimize import fsolve
 
-from .utils import calculate_correlation_lengths
-
 
 # CODE & NUMBER HANDLING ROUTINES
 #
@@ -19,9 +17,8 @@ def find_true_std(sigma, clip_limit, clipped_std):
     return sigma**2*(help2-2*numpy.sqrt(2)*help1*numpy.exp(-help1**2))-clipped_std**2*help2
 
 
-def indep_pixels(n, beam):
-    corlengthlong, corlengthshort = calculate_correlation_lengths(
-        beam[0], beam[1])
+def indep_pixels(n, correlation_lengths):
+    corlengthlong, corlengthshort = correlation_lengths
     correlated_area = 0.25 * numpy.pi * corlengthlong * corlengthshort
     return n / correlated_area
 

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -43,7 +43,7 @@ class TestFluxErrors(unittest.TestCase):
         self.assertGreaterEqual(self.p['flux'].error, 0)
 
     def test_positive_flux_moments(self):
-        self.p._error_bars_from_moments(self.noise, self.beam, self.threshold)
+        self.p._error_bars_from_moments(self.noise, self.beam, self.max_pix_variance_factor, self.threshold)
         self.assertGreaterEqual(self.p['peak'].error, 0)
         self.assertGreaterEqual(self.p['flux'].error, 0)
 
@@ -59,7 +59,7 @@ class TestFluxErrors(unittest.TestCase):
         # impossible given the current method.
         self.p['peak'] *= -1
         self.p['flux'] *= -1
-        self.p._error_bars_from_moments(self.noise, self.beam, self.threshold)
+        self.p._error_bars_from_moments(self.noise, self.beam, self.max_pix_variance_factor, self.threshold)
         self.assertEqual(self.p['peak'].error, float('inf'))
         self.assertEqual(self.p['flux'].error, float('inf'))
 

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -5,6 +5,7 @@ from sourcefinder.extract import Detection
 from sourcefinder.extract import ParamSet
 from sourcefinder.utility.coordinates import WCS
 from sourcefinder.utility.uncertain import Uncertain
+from sourcefinder.utils import maximum_pixel_method_variance
 
 
 class DummyImage(object):
@@ -36,6 +37,7 @@ class TestFluxErrors(unittest.TestCase):
         self.beam = (1.0, 1.0, 0.0)
         self.noise = 1.0  # RMS at position of source
         self.threshold = 3.0  # significance * rms at position of source
+        self.max_pix_variance_factor = maximum_pixel_method_variance(*self.beam)
 
     def test_positive_flux_condon(self):
         self.p._condon_formulae(self.noise, self.beam)

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -8,7 +8,8 @@ import numpy
 from sourcefinder.extract import source_profile_and_errors
 from sourcefinder.fitting import moments, fitgaussian, FIT_PARAMS
 from sourcefinder.gaussian import gaussian
-from sourcefinder.utils import fudge_max_pix, calculate_beamsize, maximum_pixel_method_variance
+from sourcefinder.utils import fudge_max_pix, calculate_beamsize, maximum_pixel_method_variance, \
+    calculate_correlation_lengths
 
 # The units that are tested often require information about the resolution element:
 # (semimajor(pixels),semiminor(pixels),beam position angle (radians).
@@ -313,6 +314,7 @@ class NoisyGaussTest(unittest.TestCase):
             beam=(self.semimajor, self.semiminor, self.theta),
             fudge_max_pix_factor=fudge_max_pix(self.semimajor, self.semiminor, self.theta),
             max_pix_variance_factor=maximum_pixel_method_variance(self.semimajor, self.semiminor, self.theta),
+            correlation_lengths=calculate_correlation_lengths(self.semimajor, self.semiminor),
             beamsize=calculate_beamsize(self.semimajor, self.semiminor)
         )
 


### PR DESCRIPTION
This branch was created to bypass repeated calculations of `fudge_max_pix`, `max_pix_variance`, `beamsize` and `correlation_lengths`, by adding them as an argument to the `fit` method to the `extract.Island` objects, instead of repeatedly calculating these same quantities for each island. 
Also the unit tests have been adapted to the new interfaces to e.g. `source_profile_and_errors`. 
I have mixed feelings about the commits in this branch. Yes, I achieved a considerable (~33%) speedup in `_pyse`. But I could have perhaps achieved the same speedups by using something like the `Memoize` or `functools.cache` decorator to e.g. `fudge_max_pix`. This would have required less of a code overhaul. 
And `calculate_correlation_lenths` and `calculate_beamsize` are lightweight anyway. 
After this merge it will be somewhat harder to accommodate for a varying psf across the image. This could be fixed by either going back to the situation from before all commits on this branch and adding the `functools.cache` decorators for compute intense calculations like `fudge_max_pix` or by making `fudge_max_pix_factor`, `max_pix_variance_factor`, `beamsize` and `correlation_lengths` attributes to the extract.Island objects, like `beam`. 
The latter should actually not be an attribute to the `extract.Island` objects, in the current philosophy, since it is an attribute to the `ImageData` object, so not specific for the islands. That would not be the case with a varying psf across the image. However, a varying psf would also have an effect on e.g. kappa, sigma clipping, since the correlation lengths would vary across the image. So accommodating for a varying psf would involve a major code overhaul.