### PR TITLE
Original plan for speedup did not work out, but some PEP formatting changes remain

### DIFF
--- a/sourcefinder/extract.py
+++ b/sourcefinder/extract.py
@@ -20,6 +20,22 @@ from .gaussian import gaussian
 from . import fitting
 from . import utils
 
+import time
+
+def timeit(method):
+    def timed(*args, **kw):
+        ts = time.time()
+        result = method(*args, **kw)
+        te = time.time()
+        if 'log_time' in kw:
+            name = kw.get('log_name', method._name_.upper())
+            kw['log_time'][name] = int((te - ts) * 1000)
+        else:
+            print('{0}  {1:2.2f} ms'.format(method.__name__, (te - ts) * 1000))
+        return result
+
+    return timed
+
 logger = logging.getLogger(__name__)
 
 # This is used as a dummy value, -BIGNUM values will be always be masked.
@@ -40,7 +56,7 @@ class Island(object):
     The island should provide a means of deblending: splitting itself
     apart and returning multiple sub-islands, if necessary.
     """
-
+    # @timeit
     def __init__(self, data, rms, chunk, analysis_threshold, detection_map,
                  beam, deblend_nthresh, deblend_mincont, structuring_element,
                  rms_orig=None, flux_orig=None, subthrrange=None


### PR DESCRIPTION
This branch was created to make use of processes for multiprocessing twice, for two methods, since creating processes is expensive, it takes 0.6-0.7s. The processes would already created for the fitting loop, but if we were to create them earlier, such that they can already be used for the post labelling loop (and keeping them for parallel fitting such that they do not have to recreated), we would achieve a speedup. This, however, completely failed. We started off by creating a multiprocessing Pool that we fed with the labels to a static method created to do the post labelling work. That took 10s, so way longer than before, probably because a number of maps had to be duplicated. As an instantiation method, this took forever and we had to kill the process. 

So why does the parallellisation of the fitting loop - also by applying a static method - work nicely? I guess because less data has to be copied. 

If we were to speed up the post labelling step, this would need a multithreading approach, to stay in the same memory space. Also, threads take less time to create than processes, but require some way of bypassing the GIL....Numba, Cython, exernal languages like C or Julia.

The remaining changes are the removal of a redundant import and some formatting changes to comply with PEP standards, mainly whitespaces.