### PR TITLE
This should enable a correct import of MutableMapping.

### DIFF
--- a/sourcefinder/extract.py
+++ b/sourcefinder/extract.py
@@ -5,7 +5,7 @@ These are used in conjunction with image.ImageData.
 """
 
 import logging
-from collections import MutableMapping
+from collections.abc import MutableMapping
 
 import numpy
 


### PR DESCRIPTION
Adding the `.abc` should suffice.
So now we have
`from collections.abc import MutableMapping`.

Fixes #35 