### PR TITLE
Add dask to setup

### DIFF
--- a/scripts/pyse
+++ b/scripts/pyse
@@ -35,10 +35,6 @@ from sourcefinder.accessors import writefits as tkp_writefits
 from sourcefinder.utility.cli import parse_monitoringlist_positions
 from sourcefinder.utils import generate_result_maps
 from six import print_
-from dask.distributed import Client
-
-if __name__ == '__main__':
-    client = Client()  #
 
 def regions(sourcelist):
     """

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ install_requires = """
     python-dateutil
     six
     dask[array]
+    psutil
     """.split()
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ install_requires = """
     python-casacore
     python-dateutil
     six
+    dask[array]
     """.split()
 
 


### PR DESCRIPTION
This was missing, as noticed by @dentalfloss1.
Fixes #36 

Only `dask.array` is needed, since we are only using `dask.array. map_blocks`, in `sourcefinder/image.py`.

`dask.distributed` was used in `scripts/pyse`, but seems redundant, so has been removed.

`psutil` has also been added to `setup.py`, it is needed to count the number of (logical) cores in `sourcefinder/image.py`, for `multiprocessing` through `pool.map`.