### PR TITLE
Added cmp function 

### DIFF
--- a/sourcefinder/utility/coordinates.py
+++ b/sourcefinder/utility/coordinates.py
@@ -321,6 +321,8 @@ def dmstodec(decd, decm, decs):
         raise ValueError("coordinates out of range")
     return dec
 
+def cmp(a, b):
+    return bool(a > b) - bool(a < b)
 
 def angsep(ra1, dec1, ra2, dec2):
     """Find the angular separation of two sources, in arcseconds,


### PR DESCRIPTION
Python 3 does not know the `cmp` function. 
Apparently that was still part of this repo, i.e. in line 347 of `sourcefinder/utility/coordinates.py`, in the `angsep` function.
In the tkp repo this has been corrected.

The solution, as usual, comes from [SO](https://stackoverflow.com/questions/22490366/how-to-use-cmp-in-python-3): simply add a `cmp` function.

This also fixes #6 in the sense that, using this branch, an AARTFAAC image could be correctly processed with a "Numpy version greater than 1.10.x". 
1.24.1 in this case.