### PR TITLE
extract, as called from reverse_se, needs anl as a second positional argument.

### DIFF
--- a/sourcefinder/image.py
+++ b/sourcefinder/image.py
@@ -451,7 +451,7 @@ class ImageData(object):
             labelled_data=labelled_data, labels=labels
         )
 
-    def reverse_se(self, det):
+    def reverse_se(self, det, anl):
         """Run source extraction on the negative of this image.
 
         Obviously, there should be no sources in the negative image, so this
@@ -465,7 +465,7 @@ class ImageData(object):
         self.labels.clear()
         self.clip.clear()
         self.data_bgsubbed *= -1
-        results = self.extract(det=det)
+        results = self.extract(det=det, anl=anl)
         self.data_bgsubbed *= -1
         self.labels.clear()
         self.clip.clear()

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -435,3 +435,28 @@ class TestFailureModes(unittest.TestCase):
                         msg="Data should be flat")
         with self.assertRaises(RuntimeError):
             sfimage.extract(det=5, anl=3)
+
+class TestNegationImage(unittest.TestCase):
+    """
+    Check if we do not detect any sources from the negation of a Stokes I
+    image with many sources.
+    """
+    def setUp(self):
+        fitsfile = sourcefinder.accessors.open(os.path.join(DATAPATH,
+                                                            'deconvolved.fits'))
+        self.img = ImageData(fitsfile.data, fitsfile.beam, fitsfile.wcs)
+
+    @requires_data(os.path.join(DATAPATH, 'deconvolved.fits'))
+    def testReverseSE(self):
+        """
+        We extract with a 5 sigma detection limit on the negation of an
+        artificial 2K * 2K Stokes I image with 3969 bright sources in
+        correlated noise. With this limit one should barely extract a source,
+        since erfc(5/sqrt(2))/2 * 2**22 ~ 1. This simple calculation, however,
+        assumes uncorrelated noise. A 6 sigma detection limit may be needed
+        when this test is applied to other 2K *2K images or to larger images.
+        """
+        extraction_results = self.img.reverse_se(det=5.0, anl=4.0)
+        self.assertTrue(len(extraction_results) == 0,
+                        msg=("Extracting sources from the negation of a Stokes"
+                             " I image should yield only noise peaks."))


### PR DESCRIPTION
`extract`, as called from `reverse_se`, needs `anl` as a second positional argument.
This means that `anl` should be an argument of `reverse_se`. 
Also, `reverse_se` had not been tested, so a unit test is added. 
This takes a 2K * 2K image and should extract no sources when using `reverse_se` at the 5 sigma level.

Fixes #51 