### PR TITLE
Compute moments for thin islands differently

### DIFF
--- a/sourcefinder/image.py
+++ b/sourcefinder/image.py
@@ -924,7 +924,7 @@ class ImageData(object):
                  int32[:], float32[:], int32[:])], '(n, m), (l), (n, m), ' +
                  '(), (k) -> (k), (), ()')
     def extract_parms_image_slice(some_image, inds, labelled_data, label,
-                                        dummy, maxpos, maxi, npix):
+                                  dummy, maxpos, maxi, npix):
         """
         For an island, indicated by a group of pixels with the same label,
         find the highest pixel value and its position, first relative to the

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -436,6 +436,7 @@ class TestFailureModes(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             sfimage.extract(det=5, anl=3)
 
+
 class TestNegationImage(unittest.TestCase):
     """
     Check if we do not detect any sources from the negation of a Stokes I


### PR DESCRIPTION
This commit involves considerable changes in computing moments for 'thin' islands, triggered by a logger warning, from line 1117 in image.py when processing an AARTFAAC TBB image from an infinite error in declination: 'Bad fit from blind extraction at pixel coords'. 
This was caused by computing moments for 'thin' islands in the same way as for 'thick' islands. This yielded an extreme small semi-minor axis (~1e-8 in pixel coordinates). When such an unrealistically small semi-minor axis is propagated into the error analysis, the end of the declination error bar can be outside the image. In that case wcsp2s can give 'inf'.
    
To fix this one has to reconsider computing moments for thin islands: it does not make sense to compute these if the minimal width is 1, as in the above cases. Actually, a minimal width of 2 is also dubious, since deriving 6 Gaussian parameters from four pixel values does not really make sense. That is why we here impose the same constraints wrt minimal width as for Gaussian fitting: it should be at least 3 (> 2).
    
For all other cases, i.e. 'thin' islands, only derive the peak pixel value (times fudge_max_pix) and the barycenter position. The Gaussian shape parameters are copied from the clean beam. These computations can never crash.
    
We have decided to compute this upfront, i.e. in all cases, also for 'thick' islands. This causes a duplication in computing the peak pixel value and barycenter position, since these quantities are also computed in fitting.moments. However, an investigation of the same AARTFAAC TBB image showed that 519 of 600 sources were 'thin', when analysis threshold = detection threshold = 5 * rms noise. Therefore, the duplication of these computations seems limited.

Correction in function comment: If fitted axes are LARGER than the clean beam axes, they can be deconvolved from it.