### PR TITLE
Faster testing using pytest-xdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ packages = ["sourcefinder"]
 extra-dependencies = [
     "pytest",
     "pytest-cov",
+    "pytest-xdist",
 ]
 
 [tool.hatch.envs.lint]
@@ -67,7 +68,7 @@ dependencies = [
 
 [tool.pytest.ini_options]
 testpaths = ["test"]
-addopts = ["--import-mode=importlib", "--cov=sourcefinder", "-q", "-ra"]
+addopts = ["--import-mode=importlib", "--cov=sourcefinder", "-q", "-ra", "-n=auto", "--dist=worksteal"]
 
 [tool.black]
 include = '\.pyi?$'


### PR DESCRIPTION
This is just a nice-to-have. It speed up the tests on my machine from 6 minutes down to one minute by running tests in parallel. The `--dist worksteal` is important here, because some of the tests take significantly longer than others. With worksteal enabled, if one process is testing a slow test, other processes can run the other tests in the meantime.