### PR TITLE
Enable python3.12 and test for all supported versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = {file = "LICENSE"}
 authors = [
     { name = "TKP Discovery WG", email = "discovery@transientskp.org" },
 ]
-requires-python = ">=3.10, <3.12"
+requires-python = ">=3.10, <3.13"
 dependencies = [
     "astropy",
     "dask[array]",
@@ -51,6 +51,9 @@ include = [
 packages = ["sourcefinder"]
 
 [tool.hatch.envs.test]
+matrix = [
+    {python = ["3.10", "3.11", "3.12"]}
+]
 extra-dependencies = [
     "pytest",
     "pytest-cov",


### PR DESCRIPTION
While python 3.13.0 is also released as stable, that is not yet supported by sep so we cannot use that python version yet. Python 3.12 worked without any modifications to the code.

I also specified 3.10, 3.11 and 3.12 for testing.
Now you can still just run ``PYTHONPATH=. hatch run test:pytest``, that will test all 3 python version in sequence.
You can now also run with a specific python version like so: ``PYTHONPATH=. hatch run test.py3.12:pytest``

This combines well with the other PR I made (https://github.com/transientskp/pyse/pull/83) since that one speeds up the runtime of the tests.