### PR TITLE
Fix flaw in bg calculation

### DIFF
--- a/sourcefinder/image.py
+++ b/sourcefinder/image.py
@@ -270,19 +270,19 @@ class ImageData(object):
                                               dtype=np.complex64,
                                               chunks=(1, 1)).compute()
 
-        # See also similar comment below. This solution was chosen because map_blocks does not seem to be able to
-        # output multiple arrays. One can however output to a complex array and take real and imaginary
-        # parts afterward. Not a very clean solution, I admit.
+        # See also similar comment below. This solution was chosen because
+        # map_blocks does not seem to be able to output multiple arrays. One can
+        # however output to a complex array and take real and imaginary parts
+        # afterward. Not a very clean solution, I admit.
         mode_grid = mode_and_rms.real
         rms_grid = mode_and_rms.imag
 
-        rms_grid = np.ma.array(
-            rms_grid, mask=np.where(rms_grid == 0, 1, 0), dtype=np.float32)
-        # A rms of zero is not physical, since any instrument has system noise, so I use that as criterion
-        # to mask values. A zero background mode is physically possible, but also highly unlikely, given the way
-        # we determine it.
-        mode_grid = np.ma.array(
-            mode_grid, mask=np.where(rms_grid == 0, 1, 0), dtype=np.float32)
+        # Fill in the zeroes with nearest neighbours.
+        # In this way we do not have to make a MaskedArray, which
+        # scipy.interpolate.interp1d cannot handle adequately.
+        # utils.nearest_nonzero modifies in-place.
+        utils.nearest_nonzero(mode_grid)
+        utils.nearest_nonzero(rms_grid)
 
         return {'bg': mode_grid, 'rms': rms_grid}
 

--- a/sourcefinder/image.py
+++ b/sourcefinder/image.py
@@ -263,26 +263,24 @@ class ImageData(object):
         useful_chunk = ndimage.find_objects(np.where(self.data.mask, 0, 1))
         assert (len(useful_chunk) == 1)
         y_dim = self.data[useful_chunk[0]].data.shape[1]
-        useful_data = da.from_array(self.data[useful_chunk[0]], chunks=(self.back_size_x, y_dim))
+        useful_data = da.from_array(self.data[useful_chunk[0]],
+                                    chunks=(self.back_size_x, y_dim))
 
-        mode_and_rms = useful_data.map_blocks(ImageData.compute_mode_and_rms_of_row_of_subimages,
-                                              y_dim,  self.back_size_y,
-                                              dtype=np.complex64,
-                                              chunks=(1, 1)).compute()
+        mode_and_rms = useful_data.map_blocks(
+            ImageData.compute_mode_and_rms_of_row_of_subimages, y_dim,
+            self.back_size_y, dtype=np.complex64, chunks=(1, 1)).compute()
 
         # See also similar comment below. This solution was chosen because
         # map_blocks does not seem to be able to output multiple arrays. One can
         # however output to a complex array and take real and imaginary parts
         # afterward. Not a very clean solution, I admit.
-        mode_grid = mode_and_rms.real
-        rms_grid = mode_and_rms.imag
 
         # Fill in the zeroes with nearest neighbours.
         # In this way we do not have to make a MaskedArray, which
         # scipy.interpolate.interp1d cannot handle adequately.
         # utils.nearest_nonzero modifies in-place.
-        utils.nearest_nonzero(mode_grid)
-        utils.nearest_nonzero(rms_grid)
+        mode_grid = utils.nearest_nonzero(mode_and_rms.real)
+        rms_grid = utils.nearest_nonzero(mode_and_rms.imag)
 
         return {'bg': mode_grid, 'rms': rms_grid}
 

--- a/sourcefinder/utils.py
+++ b/sourcefinder/utils.py
@@ -4,8 +4,9 @@ This module contain utilities for the source finding routines
 
 import math
 
-import numpy
+import numpy as np
 import scipy.integrate
+from scipy.ndimage import generic_filter
 
 from sourcefinder.gaussian import gaussian
 from sourcefinder.utility import coordinates
@@ -21,11 +22,11 @@ def generate_subthresholds(min_value, max_value, num_thresholds):
     # greater than the difference between max and min.
     # We subtract 1 from this to get the range between 0 and (max-min).
     # We add min to that to get the range between min and max.
-    subthrrange = numpy.logspace(
+    subthrrange = np.logspace(
         0.0,
-        numpy.log(max_value + 1 - min_value),
+        np.log(max_value + 1 - min_value),
         num=num_thresholds + 1,  # first value == min_value
-        base=numpy.e,
+        base=np.e,
         endpoint=False  # do not include max_value
     )[1:]
     subthrrange += (min_value - 1)
@@ -60,7 +61,7 @@ def get_error_radius(wcs, x_value, x_error, y_value, y_error):
             )
     except RuntimeError:
         # We get a runtime error from wcs.p2s if the errors place the
-        # limits outside of the image, in which case we set the angular
+        # limits outside the image, in which case we set the angular
         # uncertainty to infinity.
         error_radius = float('inf')
     return error_radius
@@ -72,7 +73,7 @@ def circular_mask(xdim, ydim, radius):
     the centre are set to 0; outside that region, they are set to 1.
     """
     centre_x, centre_y = (xdim - 1) / 2.0, (ydim - 1) / 2.0
-    x, y = numpy.ogrid[-centre_x:xdim - centre_x, -centre_y:ydim - centre_y]
+    x, y = np.ogrid[-centre_x:xdim - centre_x, -centre_y:ydim - centre_y]
     return x * x + y * y >= radius * radius
 
 
@@ -83,8 +84,8 @@ def generate_result_maps(data, sourcelist):
     showing the sources themselves and the other the residual after the
     sources have been removed from the input data.
     """
-    residual_map = numpy.array(data)  # array constructor copies by default
-    gaussian_map = numpy.zeros(residual_map.shape)
+    residual_map = np.array(data)  # array constructor copies by default
+    gaussian_map = np.zeros(residual_map.shape)
     for src in sourcelist:
         # Include everything with 6 times the std deviation along the major
         # axis. Should be very very close to 100% of the flux.
@@ -105,9 +106,9 @@ def generate_result_maps(data, sourcelist):
             src.smin.value,
             src.theta.value
         )(
-            numpy.indices(residual_map.shape)[0, lower_bound_x:upper_bound_x,
+            np.indices(residual_map.shape)[0, lower_bound_x:upper_bound_x,
                                               lower_bound_y:upper_bound_y],
-            numpy.indices(residual_map.shape)[1, lower_bound_x:upper_bound_x,
+            np.indices(residual_map.shape)[1, lower_bound_x:upper_bound_x,
                                               lower_bound_y:upper_bound_y]
         )
 
@@ -144,7 +145,7 @@ def calculate_correlation_lengths(semimajor, semiminor):
 def calculate_beamsize(semimajor, semiminor):
     """Calculate the beamsize based on the semi major and minor axes"""
 
-    return numpy.pi * semimajor * semiminor
+    return np.pi * semimajor * semiminor
 
 
 def fudge_max_pix(semimajor, semiminor, theta):
@@ -176,14 +177,14 @@ def fudge_max_pix(semimajor, semiminor, theta):
     #   Return the double (definite) integral of f1(y,x) from x=a..b
     #   and y=f2(x)..f3(x).
 
-    log20 = numpy.log(2.0)
-    cos_theta = numpy.cos(theta)
-    sin_theta = numpy.sin(theta)
+    log20 = np.log(2.0)
+    cos_theta = np.cos(theta)
+    sin_theta = np.sin(theta)
 
     def landscape(y, x):
         up = math.pow(((cos_theta * x + sin_theta * y) / semiminor), 2)
         down = math.pow(((cos_theta * y - sin_theta * x) / semimajor), 2)
-        return numpy.exp(log20 * (up + down))
+        return np.exp(log20 * (up + down))
 
     (correction, abserr) = scipy.integrate.dblquad(landscape, -0.5, 0.5,
                                                    lambda ymin: -0.5,
@@ -214,19 +215,16 @@ def maximum_pixel_method_variance(semimajor, semiminor, theta):
     #   Return the double (definite) integral of f1(y,x) from x=a..b
     #   and y=f2(x)..f3(x).
 
-    log20 = numpy.log(2.0)
-    cos_theta = numpy.cos(theta)
-    sin_theta = numpy.sin(theta)
+    log20 = np.log(2.0)
+    cos_theta = np.cos(theta)
+    sin_theta = np.sin(theta)
 
     def landscape(y, x):
-        return numpy.exp(2.0 * log20 *
-                         (
-                         math.pow(((cos_theta * x + sin_theta * y) / semiminor),
+        return np.exp(2.0 * log20 * (
+                      math.pow(((cos_theta * x + sin_theta * y) / semiminor),
                                   2) +
-                         math.pow(((cos_theta * y - sin_theta * x) / semimajor),
-                                  2)
-                         )
-                         )
+                      math.pow(((cos_theta * y - sin_theta * x) / semimajor),
+                                  2)))
 
     (result, abserr) = scipy.integrate.dblquad(landscape, -0.5, 0.5,
                                                lambda ymin: -0.5,
@@ -249,8 +247,72 @@ def flatten(nested_list):
         flattened = list(flatten(nested)).
     """
     for elem in nested_list:
-        if isinstance(elem, (tuple, list, numpy.ndarray)):
+        if isinstance(elem, (tuple, list, np.ndarray)):
             for i in flatten(elem):
                 yield i
         else:
             yield elem
+
+
+# “The nearest_nonzero function has been generated using ChatGPT 4.0.
+# Its AI-output has been verified for correctness, accuracy and
+# completeness, adapted where needed, and approved by the author.”
+def nearest_nonzero(some_arr):
+    """
+    Replace zeros in a 2D array with the nearest non-zero neighbor value.
+
+    This function iteratively fills zero values in a 2D Numpy array by
+    replacing each zero with the nearest non-zero neighbor in its local
+    3x3 neighborhood. It continues this process until no zeros remain,
+    propagating non-zero values efficiently. This method is optimized for
+    binary arrays with evenly distributed zeros and ones, where
+    neighborhood-based filling converges quickly.
+
+    Parameters
+    ----------
+    some_arr : np.ndarray
+        A 2D Numpy array of integers or floats containing zero and non-zero
+        values. The function modifies this array in place, filling all zeros
+        with their nearest non-zero neighbor values.
+
+    Returns
+    -------
+    np.ndarray
+        The modified array where all initial zero values are replaced by the
+        nearest non-zero neighbors. The array is updated in place but also
+        returned for convenience.
+
+    Notes
+    -----
+    - This function is particularly efficient on binary arrays or arrays
+      where zeros and non-zero values are evenly distributed.
+    - For very large arrays or arrays with isolated zero regions, other
+      methods (e.g., KDTree-based search) may be worth considering.
+
+    Example
+    -------
+    >>> arr = np.array([
+    ...     [0, 2, 0, 4],
+    ...     [1, 0, 0, 0],
+    ...     [0, 0, 3, 0],
+    ...     [0, 0, 0, 5]
+    ... ])
+    >>> nearest_nonzero(some_arr)
+    array([[2, 2, 3, 4],
+           [1, 2, 3, 4],
+           [1, 3, 3, 5],
+           [3, 3, 5, 5]])
+    """
+    def fill_zero(values):
+        center = values[len(values) // 2]
+        if center != 0:
+            return center
+        nonzero_neighbors = values[values != 0]
+        return nonzero_neighbors[0] if len(nonzero_neighbors) > 0 else 0
+
+    mask = some_arr == 0
+    while np.any(mask):
+        some_arr[mask] = generic_filter(some_arr, fill_zero, size=3)[mask]
+        mask = some_arr == 0
+
+    return some_arr


### PR DESCRIPTION
Fixes #67 
Fixes #88 

The problem is well described as part of that second issue.

In summary: previously masks were not fully accounted for in calculating the background characteristics.
After [commit 3a7919a](https://github.com/transientskp/pyse/pull/87/commits/3a7919aa78642fbcc1fba4b716d1db36130421f9) this was fixed, but subsequently the masks of (partially) masked subimages - centered on grid nodes - were not fully accounted for or led to `RuntimeWarning: invalid value encountered in scalar divide`.

Grid node values centered on (partially) masked subimages are now first set to zero and then replaced by its nearest nonzero neighbour. 
This means that `rms_grid` and `mode_grid` do not have a mask, they are regular Numpy ndarrays.
That is a better way of working since `scipy.interpolate.interp1d` in `ImageData._interpolate` cannot handle masked grid values. 
Previously, only its `data` attribute - including the zeroes - was propagated, which led to rms noise values that were too low.