### PR TITLE
Fix 95

### DIFF
--- a/sourcefinder/utils.py
+++ b/sourcefinder/utils.py
@@ -278,9 +278,23 @@ def nearest_nonzero(some_arr, rms):
     if some_arr.shape != rms.shape:
         raise ValueError("some_arr and rms must have the same shape.")
     
-    # Handle empty array or single-element array
-    if some_arr.size < 2:
+    # Handle empty array.
+    if some_arr.size == 0:
         return some_arr
+
+    # Handle single-element array.
+    if some_arr.size == 1:
+        if rms[0, 0] == 0:
+            # Return an empty array if the single value in rms is 0.
+            # A rms of 0, means a standard deviation of zero, which means we
+            # cannot do any form of thresholding for source detection. If we
+            # return an empty background grid, ImageData._interpolate will
+            # return a completely masked background map, such that no sources
+            # will be detected.
+            return np.empty((0, 0))
+        else:
+            return some_arr  # No replacement needed if rms[0, 0] is non-zero.
+
 
     # Create a mask for zero values in rms
     zero_mask = rms == 0

--- a/sourcefinder/utils.py
+++ b/sourcefinder/utils.py
@@ -257,32 +257,46 @@ def flatten(nested_list):
 # “The nearest_nonzero function has been generated using ChatGPT 4.0.
 # Its AI-output has been verified for correctness, accuracy and
 # completeness, adapted where needed, and approved by the author.”
-def nearest_nonzero(test_array):
+def nearest_nonzero(some_arr, rms):
     """
-    Replace zeros in test_array with the nearest non-zero values based on
-    distance.
+    Replace values in some_arr based on the nearest non-zero values in rms.
 
     Parameters
     ----------
-    test_array : np.ndarray
-        A 2D array where zeros will be replaced by the nearest non-zero values.
+    some_arr : np.ndarray
+        A 2D array whose values will be replaced where rms == 0.
+    rms : np.ndarray
+        A 2D array of the same shape as some_arr. Nearest non-zero neighbors
+        in rms determine the replacement indices for some_arr.
 
     Returns
     -------
     np.ndarray
-        A copy of test_array with zeros replaced by nearest non-zero values.
+        A copy of some_arr with values replaced based on nearest non-zero
+        neighbors in rms.
     """
-    # Create a mask for non-zero values
-    non_zero_mask = test_array != 0
+    if some_arr.shape != rms.shape:
+        raise ValueError("some_arr and rms must have the same shape.")
+    
+    # Handle empty array
+    if some_arr.size == 0:
+        return some_arr
+    
+    # Handle single-element array
+    if some_arr.shape == (1, 1):
+        return some_arr  # No replacement possible
+    
+    # Create a mask for zero values in rms
+    zero_mask = rms == 0
 
     # Calculate the distance transform and nearest non-zero indices
-    distances, nearest_indices = distance_transform_edt(~non_zero_mask,
+    distances, nearest_indices = distance_transform_edt(zero_mask,
                                                         return_indices=True)
 
-    # Use nearest indices to fill in zero positions with the nearest non-zero
-    # values
-    nearest_values = test_array[nearest_indices[0], nearest_indices[1]]
-    result = test_array.copy()
-    result[~non_zero_mask] = nearest_values[~non_zero_mask]
+    nearest_values = some_arr[nearest_indices[0], nearest_indices[1]]
+    # Use nearest indices from rms to update some_arr
+    result = some_arr.copy()
+    result[zero_mask] = nearest_values[zero_mask]
     
     return result
+

--- a/sourcefinder/utils.py
+++ b/sourcefinder/utils.py
@@ -278,14 +278,10 @@ def nearest_nonzero(some_arr, rms):
     if some_arr.shape != rms.shape:
         raise ValueError("some_arr and rms must have the same shape.")
     
-    # Handle empty array
-    if some_arr.size == 0:
+    # Handle empty array or single-element array
+    if some_arr.size < 2:
         return some_arr
-    
-    # Handle single-element array
-    if some_arr.shape == (1, 1):
-        return some_arr  # No replacement possible
-    
+
     # Create a mask for zero values in rms
     zero_mask = rms == 0
 


### PR DESCRIPTION
1. Compute the background grid on a suitable frame within the frame that encompasses all unmasked data, i.e. within 'useful_chunk = ndimage.find_objects(np.where(self.data.mask, 0, 1))'. It is centered such that its offsets wrt the edges of 'useful_chunk' are almost equal along all sides. Also, it is as large as possible within 'useful_chunk' and an integer number of times 'back_size_x' along the row indices and an integer number of times 'back_size_y' along the column indices. The result of this is that a slightly smaller portion of the image data is used, but all subimages are now properly centred on background grid nodes. The dict returned by 'ImageData.__grids' now has an extra entry 'indices', which is used by 'ImageData._interpolate'.  The new 'nearest_nonzero' function is called and requires an extra argument, the rms grid.
2. Align within 80 characters per line.
3. We are looking for the mean of the background pixels, which we approximate by a mode estimation. So, strictly speaking, mean is a more appropriate term than mode.
4. 'ImageData._interpolate' should return a completely masked map if the grid has size 0.
5. In 'ImageData._interpolate' the unmasked tuple of slices encompassing the unmasked pixels does not have to be rederived, since it has been passed on as a call argument. 
6. If there is no unmasked part of the rms map, we have to return the same number of arguments as in the opposite case.

And also a more robust `utils.nearest_nonzero`.