### PR TITLE
Fix #116

### DIFF
--- a/sourcefinder/extract.py
+++ b/sourcefinder/extract.py
@@ -210,7 +210,7 @@ class Island(object):
         try:
             measurement, gauss_island, gauss_residual = \
                 source_profile_and_errors(self.data, self.threshold(),
-                                          self.noise(), self.beam,
+                                          self.rms, self.noise(), self.beam,
                                           fudge_max_pix_factor,
                                           max_pix_variance_factor, beamsize,
                                           correlation_lengths, fixed=fixed)
@@ -681,7 +681,7 @@ class ParamSet(MutableMapping):
         return self
 
 
-def source_profile_and_errors(data, threshold, noise,
+def source_profile_and_errors(data, threshold, rms, noise,
                               beam, fudge_max_pix_factor, max_pix_variance_factor,
                               beamsize, correlation_lengths, fixed=None):
     """Return a number of measurable properties with errorbars
@@ -706,7 +706,11 @@ def source_profile_and_errors(data, threshold, noise,
         threshold (float): Threshold used for selecting pixels for the
             source (ie, building an island)
 
-        noise (float): Noise level in data
+        rms (np.ndarray or np.ma.MaskedArray): noise levels at pixel positions
+            corresponding to the data array, determined from the interpolated
+            grid of standard deviations of the background pixels.
+
+        noise (float): rms (noise level) at the maximum pixel position
 
         beam (tuple): beam parameters (semimaj,semimin,theta)
 
@@ -847,7 +851,7 @@ def source_profile_and_errors(data, threshold, noise,
         gauss_resid_filled = gauss_resid_masked
 
     param.chisq, param.reduced_chisq = fitting.goodness_of_fit(
-        gauss_resid_masked, noise, correlation_lengths)
+        gauss_resid_masked, rms, correlation_lengths)
 
     return param, gauss_island_filled, gauss_resid_filled
 

--- a/sourcefinder/fitting.py
+++ b/sourcefinder/fitting.py
@@ -143,12 +143,12 @@ def moments(data, fudge_max_pix_factor, beamsize, threshold=0):
 
                 # Set limits for the root finder similar to the bounds for
                 # Gaussian fits.
-                if peak > 0:
-                    low_bound = 0.5 * peak
-                    upp_bound = 1.5 * peak
+                if basevalue > 0:
+                    low_bound = 0.5 * basevalue
+                    upp_bound = 1.5 * basevalue
                 else:
-                    low_bound = 1.5 * peak
-                    upp_bound = 0.5 * peak
+                    low_bound = 1.5 * basevalue
+                    upp_bound = 0.5 * basevalue
 
                 # The number of iterations used for the root finder is also
                 # returned, but not used here.
@@ -443,13 +443,12 @@ def moments_enhanced(source_island, noise_island, chunkpos, posx, posy,
                 # position.
                 for i in (posx==rounded_barycenter[0]).nonzero()[0]:
                     if posy[i] == rounded_barycenter[1]:
-                        baseindex = i
-                        basevalue = source_island[baseindex]
+                        basevalue = source_island[i]
                         break
             else:
                 # The rounded barycenter position is not in source_island, so we
                 # revert to the maximum pixel position, which is always included.
-                basepos = maxpos[0], maxpos[1]
+                basepos = maxpos[0] - chunkpos[0], maxpos[1] - chunkpos[1]
                 # In this case we do not need to figure out the source_island
                 # index corresponding to the maximum pixel position, because
                 # maxi, the maximum pixel value has already been provided, as an
@@ -472,12 +471,12 @@ def moments_enhanced(source_island, noise_island, chunkpos, posx, posy,
 
                 # Set limits for the root finder similar to the bounds for
                 # Gaussian fits.
-                if peak > 0:
-                    low_bound = 0.5 * peak
-                    upp_bound = 1.5 * peak
+                if basevalue > 0:
+                    low_bound = 0.5 * basevalue
+                    upp_bound = 1.5 * basevalue
                 else:
-                    low_bound = 1.5 * peak
-                    upp_bound = 0.5 * peak
+                    low_bound = 1.5 * basevalue
+                    upp_bound = 0.5 * basevalue
 
                 # The number of iterations used for the root finder is also
                 # returned, but not used here.

--- a/sourcefinder/fitting.py
+++ b/sourcefinder/fitting.py
@@ -1017,10 +1017,6 @@ def goodness_of_fit(masked_residuals, noise, correlation_lengths):
     of datapoints less than 1! As a result, it doesn't really make sense to try
     and apply the 'degrees-of-freedom' correction, as this would likely result
     in a negative ``reduced_chisq`` value.
-    
-    Finally, note that when called from extract.source_profile_and_errors, the
-    noise-estimate at the peak-pixel is supplied, so will typically over-estimate
-    the noise and hence under-estimate the chi-squared values.
     """
     gauss_resid_normed = (masked_residuals / noise).compressed()
     chisq = np.sum(gauss_resid_normed * gauss_resid_normed)

--- a/sourcefinder/image.py
+++ b/sourcefinder/image.py
@@ -745,7 +745,8 @@ class ImageData(object):
 
         try:
             measurement, _, _ = extract.source_profile_and_errors(
-                fitme, threshold_at_pixel, self.rmsmap[int(x), int(y)],
+                fitme, threshold_at_pixel, self.rmsmap[chunk],
+                self.rmsmap[int(x), int(y)],
                 self.beam, self.fudge_max_pix_factor,
                 self.max_pix_variance_factor,
                 self.beamsize, self.correlation_lengths, fixed=fixed)
@@ -1265,7 +1266,9 @@ class ImageData(object):
                 chunk = slices[label - 1]
 
                 param = extract.ParamSet()
-                param.sig = maxis[count] / self.rmsmap.data[tuple(maxposs[count])]
+                param.sig = sig[count]
+                param.chisq = chisq[count]
+                param.reduced_chisq = reduced_chisq[count]
 
                 param["peak"] = Uncertain(moments_of_sources[count, 0, 0],
                                           moments_of_sources[count, 1, 0])

--- a/test/test_L15_12h_const.py
+++ b/test/test_L15_12h_const.py
@@ -79,10 +79,10 @@ class L15_12hConstCor(unittest.TestCase):
         self.assertEqual(len(self.results), 5)
 
     @requires_data(corrected_fits)
-    def testFluxes(self):
-        # All sources in this image are supposed to have the same flux.
-        # But they don't, because the simulation is broken, so this test
-        # checks they fall in a vaguely plausible range.
+    def testBrightnesses(self):
+        # All sources in this image are supposed to have the same peak spectral
+        # brightness. But they don't, because the simulation is broken, so this
+        # test checks they fall in a vaguely plausible range.
         for mysource in self.results:
             self.assertTrue(mysource.peak.value > 0.35)
             self.assertTrue(mysource.peak.value < 0.60)

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -3,7 +3,7 @@ Tests for elliptical Gaussian fitting code in the TKP pipeline.
 """
 import unittest
 
-import numpy
+import numpy as np
 
 from sourcefinder.extract import source_profile_and_errors
 from sourcefinder.fitting import moments, fitgaussian, FIT_PARAMS
@@ -21,14 +21,14 @@ class SimpleGaussTest(unittest.TestCase):
     """Generic, easy-to-fit elliptical Gaussian"""
 
     def setUp(self):
-        Xin, Yin = numpy.indices((500, 500))
+        Xin, Yin = np.indices((500, 500))
         self.height = 10
         self.x = 250
         self.y = 250
         self.maj = 40
         self.min = 20
         self.theta = 0
-        self.mygauss = numpy.ma.array(
+        self.mygauss = np.ma.array(
             gaussian(self.height, self.x, self.y, self.maj, self.min,
                      self.theta)(Xin, Yin))
         self.beamsize = calculate_beamsize(self.maj, self.min)
@@ -69,14 +69,14 @@ class NegativeGaussTest(SimpleGaussTest):
     """Negative Gaussian"""
 
     def setUp(self):
-        Xin, Yin = numpy.indices((500, 500))
+        Xin, Yin = np.indices((500, 500))
         self.height = -10
         self.x = 250
         self.y = 250
         self.maj = 40
         self.min = 20
         self.theta = 0
-        self.mygauss = numpy.ma.array(
+        self.mygauss = np.ma.array(
             gaussian(self.height, self.x, self.y, self.maj, self.min,
                      self.theta)(Xin, Yin))
         self.beamsize = calculate_beamsize(self.maj, self.min)
@@ -92,14 +92,14 @@ class CircularGaussTest(SimpleGaussTest):
     """Circular Gaussian: it makes no sense to measure a rotation angle"""
 
     def setUp(self):
-        Xin, Yin = numpy.indices((500, 500))
+        Xin, Yin = np.indices((500, 500))
         self.height = 10
         self.x = 250
         self.y = 250
         self.maj = 40
         self.min = 40
         self.theta = 0
-        self.mygauss = numpy.ma.array(
+        self.mygauss = np.ma.array(
             gaussian(self.height, self.x, self.y, self.maj, self.min,
                      self.theta)(Xin, Yin))
         self.beamsize = calculate_beamsize(self.maj, self.min)
@@ -118,14 +118,14 @@ class NarrowGaussTest(SimpleGaussTest):
     """Only 1 pixel wide"""
 
     def setUp(self):
-        Xin, Yin = numpy.indices((500, 500))
+        Xin, Yin = np.indices((500, 500))
         self.height = 10
         self.x = 250
         self.y = 250
         self.maj = 40
         self.min = 1
         self.theta = 0
-        self.mygauss = numpy.ma.array(gaussian(
+        self.mygauss = np.ma.array(gaussian(
             self.height, self.x, self.y, self.maj, self.min, self.theta)(Xin,
                                                                          Yin))
         self.beamsize = calculate_beamsize(self.maj, self.min)
@@ -138,14 +138,14 @@ class RotatedGaussTest(SimpleGaussTest):
     """Rotated by an angle < pi/2"""
 
     def setUp(self):
-        Xin, Yin = numpy.indices((500, 500))
+        Xin, Yin = np.indices((500, 500))
         self.height = 10
         self.x = 250
         self.y = 250
         self.maj = 40
         self.min = 20
-        self.theta = numpy.pi / 4
-        self.mygauss = numpy.ma.array(gaussian(
+        self.theta = np.pi / 4
+        self.mygauss = np.ma.array(gaussian(
             self.height, self.x, self.y, self.maj, self.min, self.theta)(Xin,
                                                                          Yin))
         self.beamsize = calculate_beamsize(self.maj, self.min)
@@ -161,14 +161,14 @@ class RotatedGaussTest2(SimpleGaussTest):
     """Rotated by an angle > pi/2; theta becomes negative"""
 
     def setUp(self):
-        Xin, Yin = numpy.indices((500, 500))
+        Xin, Yin = np.indices((500, 500))
         self.height = 10
         self.x = 250
         self.y = 250
         self.maj = 40
         self.min = 20
-        self.theta = 3 * numpy.pi / 4
-        self.mygauss = numpy.ma.array(gaussian(
+        self.theta = 3 * np.pi / 4
+        self.mygauss = np.ma.array(gaussian(
             self.height, self.x, self.y, self.maj, self.min, self.theta)(Xin,
                                                                          Yin))
         self.beamsize = calculate_beamsize(self.maj, self.min)
@@ -177,10 +177,10 @@ class RotatedGaussTest2(SimpleGaussTest):
         self.fit = fitgaussian(self.mygauss, self.moments)
 
     def testMomentAngle(self):
-        self.assertAlmostEqual(self.moments["theta"], self.theta - numpy.pi)
+        self.assertAlmostEqual(self.moments["theta"], self.theta - np.pi)
 
     def testFitAngle(self):
-        self.assertAlmostEqual(self.fit["theta"], self.theta - numpy.pi)
+        self.assertAlmostEqual(self.fit["theta"], self.theta - np.pi)
 
 
 class AxesSwapGaussTest(SimpleGaussTest):
@@ -188,14 +188,14 @@ class AxesSwapGaussTest(SimpleGaussTest):
     change the angle"""
 
     def setUp(self):
-        Xin, Yin = numpy.indices((500, 500))
+        Xin, Yin = np.indices((500, 500))
         self.height = 10
         self.x = 250
         self.y = 250
         self.maj = 20
         self.min = 40
         self.theta = 0
-        self.mygauss = numpy.ma.array(gaussian(
+        self.mygauss = np.ma.array(gaussian(
             self.height, self.x, self.y, self.maj, self.min, self.theta)(Xin,
                                                                          Yin))
         self.beamsize = calculate_beamsize(self.maj, self.min)
@@ -209,8 +209,8 @@ class AxesSwapGaussTest(SimpleGaussTest):
         # Presumably there's some numerical quirk causing different,
         # but equivalent, convergence in the optimization.
         if theta < 0:
-            theta = theta + numpy.pi
-        self.assertAlmostEqual(theta, numpy.pi / 2)
+            theta = theta + np.pi
+        self.assertAlmostEqual(theta, np.pi / 2)
 
     def testFitAngle(self):
         theta = self.fit["theta"]
@@ -218,8 +218,8 @@ class AxesSwapGaussTest(SimpleGaussTest):
         # Presumably there's some numerical quirk causing different,
         # but equivalent, convergence in the optimization.
         if theta < 0:
-            theta = theta + numpy.pi
-        self.assertAlmostEqual(theta, numpy.pi / 2)
+            theta = theta + np.pi
+        self.assertAlmostEqual(theta, np.pi / 2)
 
     def testMomentSize(self):
         self.assertAlmostEqual(self.moments["semiminor"], self.maj, 5)
@@ -235,8 +235,8 @@ class RandomGaussTest(unittest.TestCase):
     measure moments, though -- things should be fairly evenly distributed."""
 
     def setUp(self):
-        Xin, Yin = numpy.indices((500, 500))
-        self.mygauss = numpy.random.random(Xin.shape)
+        Xin, Yin = np.indices((500, 500))
+        self.mygauss = np.random.random(Xin.shape)
         self.beamsize = calculate_beamsize(beam[0], beam[1])
         self.fudge_max_pix_factor = fudge_max_pix(beam[0], beam[1], beam[2])
 
@@ -251,14 +251,14 @@ class NoisyGaussTest(unittest.TestCase):
     """Test calculation of chi-sq and fitting in presence of (artificial) noise"""
 
     def setUp(self):
-        Xin, Yin = numpy.indices((500, 500))
+        Xin, Yin = np.indices((500, 500))
         self.peak = 10
         self.xbar = 250
         self.ybar = 250
         self.semimajor = 40
         self.semiminor = 20
         self.theta = 0
-        self.mygauss = numpy.ma.array(
+        self.mygauss = np.ma.array(
             gaussian(self.peak, self.xbar, self.ybar,
                      self.semimajor, self.semiminor, self.theta)(Xin, Yin))
         self.beamsize = calculate_beamsize(self.semimajor, self.semiminor)
@@ -287,7 +287,7 @@ class NoisyGaussTest(unittest.TestCase):
 
     def test_noisy_background(self):
         # Use a fixed random state seed, so unit-test is reproducible:
-        rstate = numpy.random.RandomState(42)
+        rstate = np.random.RandomState(42)
         pixel_noise = 0.5
         self.mygauss += rstate.normal(scale=pixel_noise,
                                       size=len(self.mygauss.ravel())).reshape(
@@ -310,11 +310,15 @@ class NoisyGaussTest(unittest.TestCase):
         self.fit_w_errs, _, _ = source_profile_and_errors(
             data=self.mygauss,
             threshold=0.,
+            rms=np.ones(self.mygauss.shape) * pixel_noise,
             noise=pixel_noise,
             beam=(self.semimajor, self.semiminor, self.theta),
-            fudge_max_pix_factor=fudge_max_pix(self.semimajor, self.semiminor, self.theta),
-            max_pix_variance_factor=maximum_pixel_method_variance(self.semimajor, self.semiminor, self.theta),
-            correlation_lengths=calculate_correlation_lengths(self.semimajor, self.semiminor),
+            fudge_max_pix_factor=fudge_max_pix(self.semimajor, self.semiminor,
+                                               self.theta),
+            max_pix_variance_factor=maximum_pixel_method_variance(
+                self.semimajor, self.semiminor, self.theta),
+            correlation_lengths=calculate_correlation_lengths(
+                self.semimajor, self.semiminor),
             beamsize=calculate_beamsize(self.semimajor, self.semiminor)
         )
 

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -339,7 +339,7 @@ class TestSimpleImageSourceFind(unittest.TestCase):
         else:
             known_result = np.array(known_result_moments, dtype=np.float32)
         self.assertEqual(r.size, known_result.size)
-        self.assertTrue(np.allclose(r, known_result, atol=1e-5))
+        self.assertTrue(np.allclose(r, known_result, rtol=1e-4, equal_nan=True))
 
     @requires_data(GRB120422A)
     def testForceSourceShape(self):

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -339,7 +339,8 @@ class TestSimpleImageSourceFind(unittest.TestCase):
         else:
             known_result = np.array(known_result_moments, dtype=np.float32)
         self.assertEqual(r.size, known_result.size)
-        self.assertTrue(np.allclose(r, known_result, rtol=1e-4, equal_nan=True))
+        self.assertTrue(np.allclose(r, known_result, rtol=1e-4, atol=0,
+                                    equal_nan=True))
 
     @requires_data(GRB120422A)
     def testForceSourceShape(self):

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -308,7 +308,7 @@ class TestSimpleImageSourceFind(unittest.TestCase):
              # Significance level, beam semimajor-axis width (arcsec)
              1.06461773e+01, 1.78499710e+02,
              # Beam semiminor-axis width (arcsec), beam position angle (deg)
-             0.00000000e+00, 0.00000000e+00,  # ew_sys_err, ns_sys_err
+             ew_sys_err, ns_sys_err,
              4.97109604e+00, 1.00000000e+00,  # error_radius (arcsec), fit_type
              6.03417635e-01, 6.67105734e-01]  # chisq, reduced chisq
 
@@ -321,7 +321,7 @@ class TestSimpleImageSourceFind(unittest.TestCase):
              # Significance level, beam semimajor-axis width (arcsec)
              1.1146187e+01, 1.7876042e+02,  # Beam semiminor-axis width (arcsec),
              # Beam position angle (deg).
-             0.0000000e+00, 0.0000000e+00,  # ew_sys_err, ns_sys_err
+             ew_sys_err, ns_sys_err,
              4.6760769e+00, 0.0000000e+00,  # error_radius (arcsec), fit_type
              8.3038670e-01, 9.1803038e-01]  # chisq, reduced chisq
 


### PR DESCRIPTION
Fixes #116 

Also introduces a second "ground truth"  for the [TestSimpleImageSourceFind.testSingleSourceExtraction](https://github.com/transientskp/pyse/blob/8bd77c9ae181ade28a0f78ceeed02fe25e90ccd6/test/test_image.py#L293C9-L293C35) unit test in case (tweaked) moments are used instead of a Gaussian fit. 
This will be useful when `VECTORIZED=True` is set as default as proposed in [issue 90](https://github.com/transientskp/pyse/issues/90#issuecomment-2609654930). However, this is ground truth as a list, while we'll be it as e.g. an xarray, so some work needed there.

Fixes a bug wrt the use of `maxpos`  in `fitting.moments_enhanced`.

Slightly more accurate computation of `chisq`  and `reduced_chisq`  in `fitting.goodness_of_fit`. 
(This way of computing had already been included in `fitting.moments_enhanced`  from the beginning.)