### PR TITLE
Remove version restrictions regarding python<3.12 and numpy<2.0 by re…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,10 @@ license = {file = "LICENSE"}
 authors = [
     { name = "TKP Discovery WG", email = "discovery@transientskp.org" },
 ]
-requires-python = ">=3.10, <3.12"
+requires-python = ">=3.10"
 dependencies = [
     "astropy",
-    "numpy<2.0",
+    "numpy",
     "psutil",
     "python-casacore",
     "python-dateutil",
@@ -22,7 +22,6 @@ dependencies = [
     "scipy",
     "tomli; python_version < '3.11'",
     "numba",
-    "numba-scipy",
     "sphinx"
 ]
 

--- a/sourcefinder/stats.py
+++ b/sourcefinder/stats.py
@@ -3,13 +3,15 @@ Generic utility routines for number handling and calculating (specific)
 variances used by the TKP sourcefinder.
 """
 
+import math
 import numpy as np
-from scipy.special import erf
-import numba_scipy
 from numba import njit, guvectorize, int32, float32
 from sourcefinder.utils import newton_raphson_root_finder
 # CODE & NUMBER HANDLING ROUTINES
 
+@njit
+def erf(val):
+    return math.erf(val)
 
 @njit
 def find_true_std(sigma, clipped_std, clip_limit):


### PR DESCRIPTION
Installing pyse came with some severe restrictions of python<3.12 and numpy<2.0. Since other libraries may require numpy>2.0, this conflict bites me in the behind quite a bit. 

In this MR I remove the constraints by removing the use the big offender: numba-scipy.
Already a year ago the compatibility issue was raised in their issue tracker, see: https://github.com/numba/numba-scipy/issues/101
It seems they are understaffed and have been unable to address the compatibility thus far.

I noticed that we only need that package for the numba-compatible erf function:
https://github.com/transientskp/pyse/blob/fa510626860ce8b480f82cf8101d7acb1b76c36c/sourcefinder/stats.py#L7

Luckily for us, this is easily resolved because the builtin math library also has an erf function that can be numba compiled.

@HannoSpreeuw is there any other (experimental) use of the numba-scipy library? Or was the erf function indeed the only reason to use this package?