### PR TITLE
Reduce coverage warnings

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+concurrency = multiprocessing
+parallel = true
+sigterm = true
+

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -68,22 +68,18 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install hatch
           hatch env create test
-      - name: list coverage files for debugging before running pytest
-        run: find . -maxdepth 1 -type f -name ".coverage.*"
       - name: Run pytest
         run: |
-          hatch run test:pytest
+          hatch run test:pytest test/test_image.py -n 4 2> >(tee .coverage-stderr.log >&2)
+      - name: Fail on CoverageWarning
+        run: |
+          if grep -q "CoverageWarning" .coverage-stderr.log; then
+            echo "CoverageWarning encountered. This is likely related to pyse using multiprocessing in one of the tests. Make sure 'allow_multiprocessing=False' in the pyse image configuration"
+            exit 1
+          fi
       - name: Integration test
         run: |
           hatch run pyse --config-file test/data/config.toml --detection 5 --radius 400 --csv --force-beam test/data/GRB120422A-120429.fits
-      - name: list coverage files for debugging
-        run: find . -maxdepth 1 -type f -name ".coverage.*"
-      - name: Fail if .coverage.* files remain
-        run: |
-          if find . -maxdepth 1 -type f -name ".coverage.*" | grep -q .; then
-            echo "Unable to concatenate all .coverage.* files. This is likely related to pyse using multiprocessing in one of the tests. Make sure 'allow_multiprocessing=False' in the pyse image configuration"
-            exit 1
-          fi
 
   type-check:
     strategy:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -68,17 +68,19 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install hatch
           hatch env create test
+      - name: list coverage files for debugging before running pytest
+        run: find . -maxdepth 1 -type f -name ".coverage.*"
       - name: Run pytest
         run: |
           hatch run test:pytest
       - name: Integration test
         run: |
           hatch run pyse --config-file test/data/config.toml --detection 5 --radius 400 --csv --force-beam test/data/GRB120422A-120429.fits
-      - name: List files
-        run: ls -l ./
+      - name: list coverage files for debugging
+        run: find . -maxdepth 1 -type f -name ".coverage.*"
       - name: Fail if .coverage.* files remain
         run: |
-          if ls .coverage.* 1> /dev/null 2>&1; then
+          if find . -maxdepth 1 -type f -name ".coverage.*" | grep -q .; then
             echo "Unable to concatenate all .coverage.* files. This is likely related to pyse using multiprocessing in one of the tests. Make sure 'allow_multiprocessing=False' in the pyse image configuration"
             exit 1
           fi

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -74,6 +74,8 @@ jobs:
       - name: Integration test
         run: |
           hatch run pyse --config-file test/data/config.toml --detection 5 --radius 400 --csv --force-beam test/data/GRB120422A-120429.fits
+      - name: List files
+        run: ls -l ./
       - name: Fail if .coverage.* files remain
         run: |
           if ls .coverage.* 1> /dev/null 2>&1; then

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -74,6 +74,12 @@ jobs:
       - name: Integration test
         run: |
           hatch run pyse --config-file test/data/config.toml --detection 5 --radius 400 --csv --force-beam test/data/GRB120422A-120429.fits
+      - name: Fail if .coverage.* files remain
+        run: |
+          if ls .coverage.* 1> /dev/null 2>&1; then
+            echo "Unable to concatenate all .coverage.* files. This is likely related to pyse using multiprocessing in one of the tests. Make sure 'allow_multiprocessing=False' in the pyse image configuration"
+            exit 1
+          fi
 
   type-check:
     strategy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ dependencies = [
 
 [tool.pytest.ini_options]
 testpaths = ["test"]
-addopts = ["--import-mode=importlib", "--cov=sourcefinder", "-v", "-ra",
+addopts = ["--import-mode=importlib", "--cov=sourcefinder", "-q", "-ra",
            "-n=logical", "--dist=worksteal", "--cov-config=.coveragerc", "--cov-append"]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ dependencies = [
 [tool.pytest.ini_options]
 testpaths = ["test"]
 addopts = ["--import-mode=importlib", "--cov=sourcefinder", "-q", "-ra",
-           "-n=logical", "--dist=worksteal", "--cov-config=test/.coveragerc"]
+           "-n=logical", "--dist=worksteal", "--cov-config=.coveragerc"]
 
 [tool.black]
 include = '\.pyi?$'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ dependencies = [
 
 [tool.pytest.ini_options]
 testpaths = ["test"]
-addopts = ["--import-mode=importlib", "--cov=sourcefinder", "-q", "-ra",
+addopts = ["--import-mode=importlib", "--cov=sourcefinder", "-v", "-ra",
            "-n=logical", "--dist=worksteal", "--cov-config=.coveragerc", "--cov-append"]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ dependencies = [
 [tool.pytest.ini_options]
 testpaths = ["test"]
 addopts = ["--import-mode=importlib", "--cov=sourcefinder", "-q", "-ra",
-           "-n=logical", "--dist=worksteal", "--cov-config=.coveragerc"]
+           "-n=logical", "--dist=worksteal", "--cov-config=.coveragerc", "--cov-append"]
 
 [tool.black]
 include = '\.pyi?$'

--- a/test/.coveragerc
+++ b/test/.coveragerc
@@ -1,2 +1,0 @@
-[run]
-parallel = true

--- a/test/test_L15_12h_const.py
+++ b/test/test_L15_12h_const.py
@@ -6,7 +6,7 @@ import gc
 import os
 import unittest
 
-from sourcefinder.config import Conf, ImgConf
+from sourcefinder.config import Conf, ImgConf, ExportSettings
 
 from .conftest import DATAPATH
 from sourcefinder.testutil.decorators import requires_data
@@ -41,7 +41,19 @@ class L15_12hConstObs(unittest.TestCase):
                                                               beam=(0.2299,
                                                                     0.1597,
                                                                     -23.87))
-        self.image = image.ImageData(fitsfile.data, fitsfile.beam, fitsfile.wcs)
+        conf = Conf(
+            image=ImgConf(
+                # Disallow multiprocessing to enable parallel running of tests using pytest-xdist
+                allow_multiprocessing=False
+            ),
+            export=ExportSettings()
+        )
+        self.image = image.ImageData(
+            fitsfile.data,
+            fitsfile.beam,
+            fitsfile.wcs,
+            conf=conf,
+        )
         self.results = self.image.extract(det=10, anl=3.0)
 
     def tearDown(self):
@@ -68,7 +80,19 @@ class L15_12hConstCor(unittest.TestCase):
                                                               beam=(0.2299,
                                                                     0.1597,
                                                                     -23.87))
-        self.image = image.ImageData(fitsfile.data, fitsfile.beam, fitsfile.wcs)
+        conf = Conf(
+            image=ImgConf(
+                # Disallow multiprocessing to enable parallel running of tests using pytest-xdist
+                allow_multiprocessing=False
+            ),
+            export=ExportSettings()
+        )
+        self.image = image.ImageData(
+            fitsfile.data,
+            fitsfile.beam,
+            fitsfile.wcs,
+            conf=conf,
+        )
         self.results = self.image.extract(det=10.0, anl=3.0)
 
     def tearDown(self):
@@ -114,7 +138,11 @@ class L15_12hConstMod(unittest.TestCase):
                                                                     0.1597,
                                                                     -23.87))
         self.image = image.ImageData(
-            fitsfile.data, fitsfile.beam, fitsfile.wcs, Conf(ImgConf(radius=100), {})
+            fitsfile.data, fitsfile.beam, fitsfile.wcs, Conf(ImgConf(
+                radius=100,
+                # Disallow multiprocessing to enable parallel running of tests using pytest-xdist
+                allow_multiprocessing=False
+            ), {})
         )
         self.results = self.image.extract(det=5, anl=3.0)
 
@@ -142,8 +170,19 @@ class FitToPointTestCase(unittest.TestCase):
                                                               beam=(2. * 500.099 / 3600,
                                                                     2. * 319.482 / 3600,
                                                                     168.676))
-        self.my_im = image.ImageData(fitsfile.data, fitsfile.beam,
-                                     fitsfile.wcs)
+        conf = Conf(
+            image=ImgConf(
+                # Disallow multiprocessing to enable parallel running of tests using pytest-xdist
+                allow_multiprocessing=False
+            ),
+            export=ExportSettings()
+        )
+        self.my_im = image.ImageData(
+            fitsfile.data,
+            fitsfile.beam,
+            fitsfile.wcs,
+            conf=conf,
+        )
 
     def tearDown(self):
         del self.my_im

--- a/test/test_aartfaaccasatable.py
+++ b/test/test_aartfaaccasatable.py
@@ -6,6 +6,7 @@ from sourcefinder import accessors
 from sourcefinder.accessors.aartfaaccasaimage import AartfaacCasaImage
 from sourcefinder.testutil.decorators import requires_data
 from sourcefinder.utility.coordinates import angsep
+from sourcefinder.config import Conf, ImgConf, ExportSettings
 from .conftest import DATAPATH
 
 
@@ -19,8 +20,19 @@ class TestAartfaacCasaImage(unittest.TestCase):
         cls.accessor = AartfaacCasaImage(casatable)
 
     def test_casaimage(self):
+        conf = Conf(
+            image=ImgConf(
+                # Disallow multiprocessing to enable parallel running of tests using pytest-xdist
+                allow_multiprocessing=False
+            ),
+            export=ExportSettings()
+        )
+
         results = self.accessor.extract_metadata()
-        sfimage = accessors.sourcefinder_image_from_accessor(self.accessor)
+        sfimage = accessors.sourcefinder_image_from_accessor(
+            self.accessor,
+            conf=conf,
+        )
 
         known_bmaj, known_bmin, known_bpa = 4.4586, 4.458, 0
         bmaj, bmin, bpa = self.accessor.beam
@@ -58,4 +70,3 @@ class TestAartfaacCasaImage(unittest.TestCase):
         #  => Approx 0.15 arcseconds drift across 512 pixels
         # (Probably OK).
         self.assertAlmostEqual(abs(coord_dist_deg), abs(pix_dist_deg), places=3)
-

--- a/test/test_amicasatable.py
+++ b/test/test_amicasatable.py
@@ -6,6 +6,7 @@ from sourcefinder import accessors
 from sourcefinder.accessors.amicasaimage import AmiCasaImage
 from sourcefinder.testutil.decorators import requires_data
 from sourcefinder.utility.coordinates import angsep
+from sourcefinder.config import Conf, ImgConf, ExportSettings
 from .conftest import DATAPATH
 
 
@@ -19,8 +20,19 @@ class TestAmiLaCasaImage(unittest.TestCase):
         cls.accessor = AmiCasaImage(casatable)
 
     def test_casaimage(self):
+        conf = Conf(
+            image=ImgConf(
+                # Disallow multiprocessing to enable parallel running of tests using pytest-xdist
+                allow_multiprocessing=False
+            ),
+            export=ExportSettings()
+        )
+
         results = self.accessor.extract_metadata()
-        sfimage = accessors.sourcefinder_image_from_accessor(self.accessor)
+        sfimage = accessors.sourcefinder_image_from_accessor(
+            self.accessor,
+            conf=conf,
+        )
 
         known_bmaj, known_bmin, known_bpa = (4.002118682861328,
                                             2.4657058715820312,
@@ -61,4 +73,3 @@ class TestAmiLaCasaImage(unittest.TestCase):
         #  => Approx 0.15 arcseconds drift across 512 pixels
         # (Probably OK).
         self.assertAlmostEqual(abs(coord_dist_deg), abs(pix_dist_deg), places=6)
-

--- a/test/test_fits_accessors.py
+++ b/test/test_fits_accessors.py
@@ -9,6 +9,7 @@ from sourcefinder import accessors
 from sourcefinder.accessors.fitsimage import FitsImage
 from sourcefinder.testutil.decorators import requires_data
 from sourcefinder.testutil.decorators import requires_database
+from sourcefinder.config import Conf, ImgConf, ExportSettings
 from .conftest import DATAPATH
 
 
@@ -48,9 +49,18 @@ class PyfitsFitsImage(unittest.TestCase):
 
     @requires_data(os.path.join(DATAPATH, 'observed-all.fits'))
     def testSFImageFromFITS(self):
+        conf = Conf(
+            image=ImgConf(
+                # Disallow multiprocessing to enable parallel running of tests using pytest-xdist
+                allow_multiprocessing=False
+            ),
+            export=ExportSettings()
+        )
         fits_file = os.path.join(DATAPATH, 'observed-all.fits')
         image = FitsImage(fits_file, beam=(54./3600, 54./3600, 0.))
-        sfimage = accessors.sourcefinder_image_from_accessor(image)
+        sfimage = accessors.sourcefinder_image_from_accessor(
+            image, conf=conf
+        )
 
 
 
@@ -91,9 +101,18 @@ class TestFitsImage(unittest.TestCase):
 
     @requires_data(os.path.join(DATAPATH, 'observed-all.fits'))
     def testSFImageFromFITS(self):
+        conf = Conf(
+            image=ImgConf(
+                # Disallow multiprocessing to enable parallel running of tests using pytest-xdist
+                allow_multiprocessing=False
+            ),
+            export=ExportSettings()
+        )
         image = FitsImage(os.path.join(DATAPATH, 'observed-all.fits'),
                                    beam=(54./3600, 54./3600, 0.))
-        sfimage = accessors.sourcefinder_image_from_accessor(image)
+        sfimage = accessors.sourcefinder_image_from_accessor(
+            image, conf=conf
+        )
 
 
 

--- a/test/test_kat7casatable.py
+++ b/test/test_kat7casatable.py
@@ -6,6 +6,7 @@ from sourcefinder import accessors
 from sourcefinder.accessors.kat7casaimage import Kat7CasaImage
 from sourcefinder.testutil.decorators import requires_data
 from sourcefinder.utility.coordinates import angsep
+from sourcefinder.config import Conf, ImgConf, ExportSettings
 from .conftest import DATAPATH
 
 
@@ -19,8 +20,18 @@ class TestKat7CasaImage(unittest.TestCase):
         cls.accessor = Kat7CasaImage(casatable)
 
     def test_casaimage(self):
+        conf = Conf(
+            image=ImgConf(
+                # Disallow multiprocessing to enable parallel running of tests using pytest-xdist
+                allow_multiprocessing=False
+            ),
+            export=ExportSettings()
+        )
         results = self.accessor.extract_metadata()
-        sfimage = accessors.sourcefinder_image_from_accessor(self.accessor)
+        sfimage = accessors.sourcefinder_image_from_accessor(
+            self.accessor,
+            conf=conf,
+        )
 
         known_bmaj, known_bmin, known_bpa = 3.33, 3.33, 0
         bmaj, bmin, bpa = self.accessor.beam
@@ -58,4 +69,3 @@ class TestKat7CasaImage(unittest.TestCase):
         #  => Approx 0.15 arcseconds drift across 512 pixels
         # (Probably OK).
         self.assertAlmostEqual(abs(coord_dist_deg), abs(pix_dist_deg), places=6)
-

--- a/test/test_lofarcasatable.py
+++ b/test/test_lofarcasatable.py
@@ -7,6 +7,7 @@ from sourcefinder.accessors.lofaraccessor import LofarAccessor
 from sourcefinder.accessors.lofarcasaimage import LofarCasaImage
 from sourcefinder.testutil.decorators import requires_data
 from sourcefinder.utility.coordinates import angsep
+from sourcefinder.config import Conf, ImgConf, ExportSettings
 from .conftest import DATAPATH
 
 
@@ -19,9 +20,19 @@ class TestLofarCasaImage(unittest.TestCase):
         self.accessor = LofarCasaImage(casatable)
 
     def test_casaimage(self):
+        conf = Conf(
+            image=ImgConf(
+                # Disallow multiprocessing to enable parallel running of tests using pytest-xdist
+                allow_multiprocessing=False
+            ),
+            export=ExportSettings()
+        )
         self.assertTrue(isinstance(self.accessor, LofarAccessor))
         results = self.accessor.extract_metadata()
-        sfimage = accessors.sourcefinder_image_from_accessor(self.accessor)
+        sfimage = accessors.sourcefinder_image_from_accessor(
+            self.accessor,
+            conf=conf,
+        )
 
         known_bmaj, known_bmin, known_bpa = 2.64, 1.85, 1.11
         bmaj, bmin, bpa = self.accessor.beam

--- a/test/test_source_measurements.py
+++ b/test/test_source_measurements.py
@@ -19,6 +19,7 @@ import unittest
 import numpy as np
 from .conftest import DATAPATH
 from sourcefinder.testutil.decorators import requires_data, duration
+from sourcefinder.config import Conf, ImgConf
 
 import sourcefinder.accessors
 from sourcefinder import image
@@ -41,8 +42,16 @@ class SourceParameters(unittest.TestCase):
     def setUp(self):
         fitsfile = sourcefinder.accessors.open(os.path.join(DATAPATH,
                                                             'deconvolved.fits'))
-        img = image.ImageData(fitsfile.data, fitsfile.beam,
-                              fitsfile.wcs)
+        conf = conf=Conf(ImgConf(
+            # Disallow multiprocessing to enable parallel running of tests using pytest-xdist
+            allow_multiprocessing=False,
+        ), {})
+        img = image.ImageData(
+            fitsfile.data,
+            fitsfile.beam,
+            fitsfile.wcs,
+            conf=conf,
+        )
 
         # This is quite subtle. We bypass any possible flaws in the
         # kappa, sigma clipping algorithm by supplying a background


### PR DESCRIPTION
PR https://github.com/transientskp/pyse/pull/83 introduced coverage warnings. I thought I addressed those but that was not quite the case, see https://github.com/transientskp/pyse/pull/139#issuecomment-2952188633 .

In this PR I will make another attempt. It  seems to me the following was happening:
In test_pyse.py we call the pyse cli using a subprocess. The reason to do it this way was to also include the CLI interface in the test, but it does mean that pytest-cov is not able to gather any information regarding the code coverage. Since no other parts of the package are executed, the coverage files regarding theses tests are empty. A warning is raised at the end when pytest-cov reads all .coverage files to combine the statistics. This is something pytest-cov does not handle (see: ), but we can twiddle a bit with the settings to the coverage package that pytest-cov is using under the hood by supplying a .coveragerc. This also only seems to work if it is placed in the root folder which is the mistake I made before. After this it seems that one warning remains, that I have not been able to track down yet.