### PR TITLE
Re-enable parallel make_subimages

### DIFF
--- a/sourcefinder/utils.py
+++ b/sourcefinder/utils.py
@@ -417,7 +417,7 @@ def nearest_nonzero(some_arr, rms):
 # “The make_subimages function has been generated using ChatGPT 4.0.
 # Its AI-output has been verified for correctness, accuracy and
 # completeness, adapted where needed, and approved by the author.”
-@njit()
+@njit(parallel=True)
 def make_subimages(a_data, a_mask, back_size_x, back_size_y):
     """
     Reshape the image data such that it is suitable for guvectorized


### PR DESCRIPTION
It seems there should be no warnings left, also not when I enable `@njit(parallel=True) ` again it seems to be fine, let's see what the cicd does