### PR TITLE
Build API docs w/ Sphinx and autoapi

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,7 +20,6 @@ release = sourcefinder.__version__
 
 extensions = [
     "sphinx.ext.autodoc",
-    "sphinx.ext.autodoc.typehints",
     "sphinx.ext.autosummary",
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
@@ -28,6 +27,8 @@ extensions = [
     "numpydoc",
     "autoapi.extension",
 ]
+
+autodoc_typehints = "both"
 
 # autoapi_keep_files = True
 autoapi_dirs = ["../../sourcefinder"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,55 +1,50 @@
-# Configuration file for the Sphinx documentation builder.
-#
-# This file only contains a selection of the most common options. For a full
-# list see the documentation:
-# https://www.sphinx-doc.org/en/master/usage/configuration.html
+import sourcefinder
 
-# -- Path setup --------------------------------------------------------------
+project = "PySE"
+authors = [
+    "Hanno Spreeuw",
+    "John Swinbank",
+    "Gijs Molenaar",
+    "Tim Staley",
+    "Evert Rol",
+    "John Sanders",
+    "Bart Scheers",
+    "Mark Kuiack",
+    "Suvayu Ali",
+    "Timo Millenaar",
+    "Antonia Rowlinson",
+]
+author = ", ".join(authors)
+copyright = ", ".join(["2024", *authors])
+release = sourcefinder.__version__
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-#
-import os
-import sys
-sys.path.insert(0, os.path.abspath('../..'))
-
-
-# -- Project information -----------------------------------------------------
-
-project = 'PySE'
-copyright = '2024, Hanno Spreeuw, John Swinbank, Gijs Molenaar, Tim Staley, Evert Rol, John Sanders, Bart Scheers, Mark Kuiack, Suvayu Ali, Timo Millenaar, Antonia Rowlinson'
-author = 'Hanno Spreeuw, John Swinbank, Gijs Molenaar, Tim Staley, Evert Rol, John Sanders, Bart Scheers, Mark Kuiack, Suvayu Ali, Timo Millenaar, Antonia Rowlinson'
-
-# The full version, including alpha/beta/rc tags
-release = '0.3.2'
-
-
-# -- General configuration ---------------------------------------------------
-
-# Add any Sphinx extension module names here, as strings. They can be
-# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
-# ones.
 extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autodoc.typehints",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.extlinks",
+    "numpydoc",
+    "autoapi.extension",
 ]
 
-# Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+# autoapi_keep_files = True
+autoapi_dirs = ["../../sourcefinder"]
+autoapi_options = [
+    "members",
+    "undoc-members",
+    "private-members",
+    "show-inheritance",
+    "show-module-summary",
+    "imported-members",
+]
+autoapi_member_order = "groupwise"
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-# This pattern also affects html_static_path and html_extra_path.
+templates_path = ["_templates"]
+
+# source file discovery
 exclude_patterns = []
 
-
-# -- Options for HTML output -------------------------------------------------
-
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-#
-html_theme = 'alabaster'
-
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# HTML options
+html_theme = "furo"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,8 +1,3 @@
-.. PySE documentation master file, created by
-   sphinx-quickstart on Mon Dec  2 11:27:46 2024.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 Welcome to PySE's documentation!
 ================================
 
@@ -10,8 +5,6 @@ Welcome to PySE's documentation!
    :maxdepth: 2
 
    README
-
-
 
 
 Indices and tables

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,8 +61,8 @@ extra-dependencies = [
     "pytest-cov",
 ]
 
-[tool.hatch.envs.default_312]
-python = "3.12"
+[tool.hatch.envs.py_oldest]
+python = "3.10"
 extra-dependencies = [
     "pytest",
     "pytest-cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,14 @@ dependencies = [
     "ruff",
 ]
 
+[tool.hatch.envs.docs]
+extra-dependencies = [
+    "furo",
+    "numpydoc",
+    "sphinx",
+    "sphinx-autoapi",
+]
+
 [tool.pytest.ini_options]
 testpaths = ["test"]
 addopts = ["--import-mode=importlib", "--cov=sourcefinder", "-q", "-ra", "--cov-append"]

--- a/sourcefinder/accessors/aartfaaccasaimage.py
+++ b/sourcefinder/accessors/aartfaaccasaimage.py
@@ -8,8 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 class AartfaacCasaImage(CasaImage):
-    """
-    A class to represent an AARTFAAC CASA image, extending the CasaImage class.
+    """A class to represent an AARTFAAC CASA image, extending the CasaImage class.
 
     Parameters
     ----------
@@ -19,6 +18,7 @@ class AartfaacCasaImage(CasaImage):
         If the data is a cube, specifies which plane to use.
     beam : tuple, default: None
         Beam parameters in degrees, in the form (bmaj, bmin, bpa).
+
     """
     def __init__(self, url, plane=0, beam=None):
         super().__init__(url, plane=0, beam=None)
@@ -31,8 +31,8 @@ class AartfaacCasaImage(CasaImage):
         self.tau_time = 1
 
     def parse_frequency(self, table):
-        """
-        Extract frequency-related information from the casacore table.
+        """Extract frequency-related information from the casacore
+        table.
 
         This method overrides the implementation in the `CasaImage` class,
         which retrieves the entries from the 'spectral2' sub-table.
@@ -45,13 +45,11 @@ class AartfaacCasaImage(CasaImage):
         Returns
         -------
         tuple
-            A tuple containing:
-            - freq_eff : float
-                The effective frequency (rest frequency) in Hz extracted from
-                the casacore table.
-            - freq_bw : float
-                The frequency bandwidth in Hz, derived from the WCS 'cdelt'
-                value in the casacore table.
+            - freq_eff (float): The effective frequency (rest
+              frequency) in Hz extracted from the casacore table.
+            - freq_bw (float): The frequency bandwidth in Hz, derived
+              from the WCS 'cdelt' value in the casacore table.
+
         """
         keywords = table.getkeywords()
 

--- a/sourcefinder/accessors/dataaccessor.py
+++ b/sourcefinder/accessors/dataaccessor.py
@@ -13,22 +13,22 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class DataAccessor:
-    """
-    Base class for accessors used with :class:`sourcefinder.image.ImageData`.
-    
+    """Base class for accessors used with
+    :class:`sourcefinder.image.ImageData`.
+
     Data accessors provide a uniform way for the ImageData class (i.e.,
     generic image representation) to access the various ways in which
     images may be stored (FITS files, arrays in memory, potentially HDF5,
     etc.).
-    
+
     This class cannot be instantiated directly, but should be subclassed
     and the abstract properties provided. Note that all abstract
     properties are required to provide a valid accessor.
-    
+
     Additional properties may also be provided by subclasses. However,
     TraP components are required to degrade gracefully in the absence of
     these optional properties.
-    
+
     Attributes
     ----------
     beam : tuple
@@ -61,12 +61,13 @@ class DataAccessor:
     wcs : :class:`sourcefinder.utility.coordinates.WCS`
         An instance of :py:class:`sourcefinder.utility.coordinates.WCS`,
         describing the mapping from data pixels to sky-coordinates.
-    
+
     Notes
     -----
     The class also provides some common functionality: static methods used
     for parsing data files, and an 'extract_metadata' function which
     provides key info in a simple dict format.
+
     """
 
     centre_ra: float
@@ -87,12 +88,10 @@ class DataAccessor:
             beam_tuple = (self.conf.bmaj, self.conf.bmin, self.conf.bpa)
             if is_valid_beam_tuple(beam_tuple):
                 deltax, deltay = self.pixelsize
-                self.beam = DataAccessor.degrees2pixels(*beam_tuple,
-                                                        deltax, deltay)
+                self.beam = DataAccessor.degrees2pixels(*beam_tuple, deltax, deltay)
 
     def extract_metadata(self) -> dict:
-        """
-        Massage the class attributes into a flat dictionary with
+        """Massage the class attributes into a flat dictionary with
         database-friendly values.
 
         While rather tedious, this is easy to serialize and store separately
@@ -105,32 +104,35 @@ class DataAccessor:
         dict
             A dictionary containing key-value pairs of class attributes
             formatted for database storage.
+
         """
         metadata = {
-            'tau_time': self.tau_time,
-            'freq_eff': self.freq_eff,
-            'freq_bw': self.freq_bw,
-            'taustart_ts': self.taustart_ts,
-            'url': self.url,
-            'centre_ra': self.centre_ra,
-            'centre_decl': self.centre_decl,
-            'deltax': self.pixelsize[0],
-            'deltay': self.pixelsize[1],
+            "tau_time": self.tau_time,
+            "freq_eff": self.freq_eff,
+            "freq_bw": self.freq_bw,
+            "taustart_ts": self.taustart_ts,
+            "url": self.url,
+            "centre_ra": self.centre_ra,
+            "centre_decl": self.centre_decl,
+            "deltax": self.pixelsize[0],
+            "deltay": self.pixelsize[1],
         }
-
 
         if is_valid_beam_tuple(self.beam):
             beam = cast(tuple[float, float, float], self.beam)
-            metadata.update({
-                'beam_smaj_pix': beam[0],
-                'beam_smin_pix': beam[1],
-                'beam_pa_rad': beam[2],
-            })
+            metadata.update(
+                {
+                    "beam_smaj_pix": beam[0],
+                    "beam_smin_pix": beam[1],
+                    "beam_pa_rad": beam[2],
+                }
+            )
 
         return metadata
 
     def parse_pixelsize(self) -> tuple[float, float]:
-        """
+        """Parse pixel size.
+
         Returns
         -------
         deltax : float
@@ -154,17 +156,17 @@ class DataAccessor:
         # NB. What's a reasonable epsilon here?
         eps = 1e-7
         if abs(abs(deltax) - abs(deltay)) > eps:
-            raise ValueError("Image WCS header suggests non-square pixels."
-                             "This is an untested use case, and may break "
-                             "things - specifically the skyregion tracking "
-                             "but possibly other stuff too.")
+            raise ValueError(
+                "Image WCS header suggests non-square pixels."
+                "This is an untested use case, and may break "
+                "things - specifically the skyregion tracking "
+                "but possibly other stuff too."
+            )
         return deltax, deltay
 
     @staticmethod
-    def degrees2pixels(bmaj, bmin, bpa, deltax, deltay) -> (
-            tuple)[float, float, float]:
-        """
-        Convert beam in degrees to beam in pixels and radians.
+    def degrees2pixels(bmaj, bmin, bpa, deltax, deltay) -> (tuple)[float, float, float]:
+        """Convert beam in degrees to beam in pixels and radians.
         For example, FITS beam parameters are in degrees.
 
         Parameters
@@ -183,21 +185,16 @@ class DataAccessor:
         Returns
         -------
         tuple
-            A tuple containing:
-            - semimaj : float
-                Beam semi-major axis in pixels.
-            - semimin : float
-                Beam semi-minor axis in pixels.
-            - theta : float
-                Beam position angle in radians.
+            - semimaj (float): Beam semi-major axis in pixels.
+            - semimin (float): Beam semi-minor axis in pixels.
+            - theta (float): Beam position angle in radians.
+
         """
         theta = pi * bpa / 180
-        semimaj = (bmaj / 2.) * (sqrt(
-            (sin(theta) ** 2) / (deltax ** 2) +
-            (cos(theta) ** 2) / (deltay ** 2))
+        semimaj = (bmaj / 2.0) * (
+            sqrt((sin(theta) ** 2) / (deltax**2) + (cos(theta) ** 2) / (deltay**2))
         )
-        semimin = (bmin / 2.) * (sqrt(
-            (cos(theta) ** 2) / (deltax ** 2) +
-            (sin(theta) ** 2) / (deltay ** 2))
+        semimin = (bmin / 2.0) * (
+            sqrt((cos(theta) ** 2) / (deltax**2) + (sin(theta) ** 2) / (deltay**2))
         )
         return semimaj, semimin, theta

--- a/sourcefinder/accessors/fitsimage.py
+++ b/sourcefinder/accessors/fitsimage.py
@@ -15,13 +15,12 @@ logger = logging.getLogger(__name__)
 
 
 class FitsImage(DataAccessor):
-    """
-    Use PyFITS to pull image data out of a FITS file.
-    
+    """Use PyFITS to pull image data out of a FITS file.
+
     Provide standard attributes, as per :class:`DataAccessor`. In addition, we
     provide a ``telescope`` attribute if the FITS file has a ``TELESCOP``
     header.
-    
+
     Parameters
     ----------
     url : str
@@ -29,10 +28,11 @@ class FitsImage(DataAccessor):
     plane : int, default: None
         If the data is a datacube, specifies which plane to use.
     beam : tuple, default: None
-        Beam parameters in degrees, in the form (bmaj, bmin, bpa). If not 
+        Beam parameters in degrees, in the form (bmaj, bmin, bpa). If not
         supplied, the method will attempt to read these from the header.
     hdu_index : int, default: 0
         The index of the HDU to use from the HDU list.
+
     """
     def __init__(self, url, plane=None, beam=None, hdu_index=0):
         self.url = url
@@ -60,8 +60,8 @@ class FitsImage(DataAccessor):
             self.telescope = self.header['TELESCOP']
 
     def _get_header(self, hdu_index):
-        """
-        Retrieve the header from the specified HDU in the FITS file.
+        """Retrieve the header from the specified HDU in the FITS
+        file.
 
         Parameters
         ----------
@@ -72,14 +72,14 @@ class FitsImage(DataAccessor):
         -------
         astropy.io.fits.Header
             A copy of the header from the specified HDU.
+
         """
         with pyfits.open(self.url) as hdulist:
             hdu = hdulist[hdu_index]
         return hdu.header.copy()
 
     def read_data(self, hdu_index, plane):
-        """
-        Read data from our FITS file.
+        """Read data from our FITS file.
 
         Parameters
         ----------
@@ -100,6 +100,7 @@ class FitsImage(DataAccessor):
         consistent with (eg) ds9 display of the FitsFile. Transpose back
         before viewing the array with RO.DS9, saving to a FITS file,
         etc.
+
         """
         with pyfits.open(self.url) as hdulist:
             hdu = hdulist[hdu_index]
@@ -115,8 +116,8 @@ class FitsImage(DataAccessor):
         return data
 
     def parse_coordinates(self):
-        """
-        Parse header to return a WCS (World Coordinate System) object.
+        """Parse header to return a WCS (World Coordinate System)
+        object.
 
         Returns
         -------
@@ -133,6 +134,7 @@ class FitsImage(DataAccessor):
         -----
         If units are not specified in the header, degrees are assumed by
         default.
+
         """
         header = self.header
         wcs = WCS()
@@ -166,8 +168,7 @@ class FitsImage(DataAccessor):
 
 
     def calculate_phase_centre(self):
-        """
-        Calculate the phase center of the FITS image.
+        """Calculate the phase center of the FITS image.
 
         The phase center is determined by finding the central pixel and
         converting that position to celestial coordinates.
@@ -177,6 +178,7 @@ class FitsImage(DataAccessor):
         tuple of float
             A tuple containing the right ascension and declination
             of the phase center in degrees.
+
         """
         x, y = self.data.shape
         centre_ra, centre_decl = self.wcs.p2s((x / 2, y / 2))
@@ -184,9 +186,8 @@ class FitsImage(DataAccessor):
 
 
     def parse_frequency(self):
-        """
-        Set some 'shortcut' variables for access to the frequency parameters
-        in the FITS file header.
+        """Set some 'shortcut' variables for access to the frequency
+        parameters in the FITS file header.
 
         Returns
         -------
@@ -194,6 +195,7 @@ class FitsImage(DataAccessor):
             A tuple containing:
             - freq_eff: The effective frequency extracted from the FITS header.
             - freq_bw: The bandwidth extracted from the FITS header.
+
         """
         freq_eff = None
         freq_bw = None
@@ -227,23 +229,20 @@ class FitsImage(DataAccessor):
 
 
     def parse_beam(self):
-        """
-        Read and return the beam properties bmaj, bmin and bpa values from
-        the FITS header.
+        """Read and return the beam properties bmaj, bmin and bpa
+        values from the FITS header.
 
         Returns
         -------
         tuple
-            A tuple containing:
-            - bmaj: float
-                The major axis of the beam in degrees.
-            - bmin: float
-                The minor axis of the beam in degrees.
-            - bpa: float
-                The position angle of the beam in degrees.
+            - bmaj (float): the major axis of the beam in degrees.
+            - bmin (float): the minor axis of the beam in degrees.
+            - bpa (float): the position angle of the beam in degrees.
+
         Notes
         -----
         AIPS FITS file: stored in the history section
+
         """
         beam_regex = re.compile(r'''
             BMAJ
@@ -269,8 +268,7 @@ class FitsImage(DataAccessor):
         except KeyError:
 
             def get_history(hdr):
-                """
-                Retrieve all history cards from a FITS header.
+                """Retrieve all history cards from a FITS header.
 
                 Parameters
                 ----------
@@ -282,8 +280,9 @@ class FitsImage(DataAccessor):
                 list of str
                     A list of strings, where each string represents a history
                     card from the FITS header.
+
                 """
-                return hdr['HISTORY']
+                return hdr["HISTORY"]
 
             for hist_entry in get_history(header):
                 results = beam_regex.search(hist_entry)
@@ -296,18 +295,16 @@ class FitsImage(DataAccessor):
 
 
     def parse_times(self):
-        """
-        Attempt to do something sane with timestamps.
+        """Attempt to do something sane with timestamps.
 
         Returns
         -------
         tuple
-            A tuple containing:
-            - taustart_ts: datetime.datetime
-                Timezone-naive (implicit UTC) datetime representing the start
-                of the observation.
-            - tau_time: float
-                Integration time in seconds.
+            - taustart_ts (datetime.datetime): Timezone-naive
+              (implicit UTC) datetime representing the start of the
+              observation.
+            - tau_time (float): Integration time in seconds.
+
         """
         try:
             start = self.parse_start_time()
@@ -342,9 +339,8 @@ class FitsImage(DataAccessor):
 
 
     def parse_start_time(self):
-        """
-        Parse and return the start time of the observation, that yielded this
-        FITS image, from its header.
+        """Parse and return the start time of the observation, that
+        yielded this FITS image, from its header.
 
         Returns
         -------
@@ -359,6 +355,7 @@ class FitsImage(DataAccessor):
         Warning
             Logged if a non-standard date format is encountered in the FITS
             file.
+
         """
         header = self.header
         try:

--- a/sourcefinder/config.py
+++ b/sourcefinder/config.py
@@ -20,7 +20,7 @@ from typing import Container
 from typing import Type
 from typing import TypeVar
 from warnings import warn
-from enum import StrEnum
+from enum import Enum
 
 T = TypeVar("T")
 
@@ -117,7 +117,7 @@ class _Validate:
 _structuring_element = [[1, 1, 1], [1, 1, 1], [1, 1, 1]]
 
 
-class SourceParam(StrEnum):
+class SourceParam(str, Enum):
     RA = "ra"
     RA_ERR = "ra_err"
     DEC = "dec"

--- a/sourcefinder/config.py
+++ b/sourcefinder/config.py
@@ -20,15 +20,16 @@ from typing import Container
 from typing import Type
 from typing import TypeVar
 from warnings import warn
-from enum import Enum
+from enum import StrEnum
 
 T = TypeVar("T")
 
 
-def unguarded_is_dataclass(_type: Type[T], /) -> bool:
-    """Remove :ref:`TypeGuard` from is_dataclass.
+def _is_dataclass(_type: Type[T], /) -> bool:
+    """Remove ``TypeGuard`` from is_dataclass.
 
     see: https://github.com/python/mypy/issues/14941
+
     """
     return is_dataclass(_type)
 
@@ -40,7 +41,7 @@ _compat_types: defaultdict[type, set[type]] = defaultdict(set, {int: {float}})
 def assert_t(key: str, value, *types: type):
     """Assert value is of one of the types
 
-    `key` is the TOML configuration key the value is associated to.
+    ``key`` is the TOML configuration key the value is associated to.
     It is used to generate a meaningful error message.
 
     """
@@ -62,13 +63,13 @@ def assert_t(key: str, value, *types: type):
 def validate_nested(key: str, value, origin_t, args):
     """Validate nested types allowed in TOML
 
-    `key` is the TOML configuration key being validated.  `value`
-    should be of type `origin_t[args]`.  It is passed to this function
-    separately to avoid recomputing the type again.
+    ``key`` is the TOML configuration key being validated.  ``value``
+    should be of type ``origin_t[args]``.  It is passed to this
+    function separately to avoid recomputing the type again.
 
-    When the type is a `list`, the value is tested recursively.  On
+    When the type is a ``list``, the value is tested recursively.  On
     recursive calls, the list index is appended to the key.  For
-    `dict`s, iterate over all key-value pairs and validated.
+    ``dict``-s, iterate over all key-value pairs and validated.
 
     """
     # NOTE: only support TOML types
@@ -90,7 +91,7 @@ def validate_nested(key: str, value, origin_t, args):
 def validate_types(key: str, value, type_: type):
     """Validate types, dispatch on generic or POD types
 
-    `key` is the TOML configuration key the value is associated to.
+    ``key`` is the TOML configuration key the value is associated to.
     It is used to generate a meaningful error message.
 
     """
@@ -115,7 +116,8 @@ class _Validate:
 
 _structuring_element = [[1, 1, 1], [1, 1, 1], [1, 1, 1]]
 
-class SourceParam(str, Enum):
+
+class SourceParam(StrEnum):
     RA = "ra"
     RA_ERR = "ra_err"
     DEC = "dec"
@@ -141,51 +143,76 @@ class SourceParam(str, Enum):
             "ra_err": "1-sigma uncertainty in right ascension (degrees)",
             "dec": "Declination of the source (degrees)",
             "dec_err": "1-sigma uncertainty in declination (degrees)",
-            "smaj_asec": ("Semi-major axis of the Gaussian profile, "
-                          "not deconvolved from the clean beam (arcseconds)"),
-            "smaj_asec_err": ("1-sigma uncertainty in the semi-major axis, "
-                              "not deconvolved from the clean beam "
-                              "(arcseconds)"),
-            "smin_asec": ("Semi-minor axis of the Gaussian profile, "
-                          "not deconvolved from the clean beam (arcsecond)"),
-            "smin_asec_err": ("1-sigma uncertainty in the semi-minor axis, "
-                              "not deconvolved from the clean beam "
-                              "(arcseconds)"),
-            "theta_celes": ("Position angle of the major axis of the "
-                           "Gaussian profile, measured east from local north "
-                           "(degrees)"),
-            "theta_celes_err": ("1-sigma uncertainty in the position angle "
-                                "of the major axis of the Gaussian profile, "
-                                "measured east from local north (degrees)"),
-            "flux": ("Flux density of the source, calculated as 'pi * peak "
-                     "spectral brightness * semi- major axis * semi-minor "
-                     "axis / beamsize' (Jy)"),
+            "smaj_asec": (
+                "Semi-major axis of the Gaussian profile, "
+                "not deconvolved from the clean beam (arcseconds)"
+            ),
+            "smaj_asec_err": (
+                "1-sigma uncertainty in the semi-major axis, "
+                "not deconvolved from the clean beam "
+                "(arcseconds)"
+            ),
+            "smin_asec": (
+                "Semi-minor axis of the Gaussian profile, "
+                "not deconvolved from the clean beam (arcsecond)"
+            ),
+            "smin_asec_err": (
+                "1-sigma uncertainty in the semi-minor axis, "
+                "not deconvolved from the clean beam "
+                "(arcseconds)"
+            ),
+            "theta_celes": (
+                "Position angle of the major axis of the "
+                "Gaussian profile, measured east from local north "
+                "(degrees)"
+            ),
+            "theta_celes_err": (
+                "1-sigma uncertainty in the position angle "
+                "of the major axis of the Gaussian profile, "
+                "measured east from local north (degrees)"
+            ),
+            "flux": (
+                "Flux density of the source, calculated as 'pi * peak "
+                "spectral brightness * semi- major axis * semi-minor "
+                "axis / beamsize' (Jy)"
+            ),
             "flux_err": "1-sigma uncertainty in the flux density (Jy)",
             "peak": "Peak spectral brightness of the source (Jy/beam)",
-            "peak_err": ("1-sigma uncertainty in the peak spectral "
-                         "brightness of the source (Jy/beam)"),
-            "x": ("x-position (float) of the barycenter of the source, "
-                  "correponding to the row index of the Numpy array with "
-                  "image data. After loading a FITS image, the data is "
-                  "transposed such that x and y are aligned with ds9 viewing, "
-                  "except for an offset of 1 pixel, since the bottom left "
-                  "pixel in ds9 has x=y=1"),
-            "y": ("y-position (float) of the barycenter of the source, "
-                  "correponding to the column index of the Numpy array with "
-                  "image data. After loading a FITS image, the data is "
-                  "transposed such that x and y are aligned with ds9 viewing, "
-                  "except for an offset of 1 pixel, since the bottom left "
-                  "pixel in ds9 has x=y=1"),
-            "sig": ("The significance of a detection (float) is defined as "
-                    "the maximum signal-to-noise ratio across the island. "
-                    "Often this will be the ratio of the maximum pixel value "
-                    "of the source divided by the noise at that position."),
-            "reduced_chisq": ("The reduced chi-squared value of the Gaussian "
-                              "model relative to the data (float). Can be a "
-                              "Gaussian model derived from a fit or from "
-                              "moments. See the measuring.goodness_of_fit "
-                              "docstring for some important notes.")
+            "peak_err": (
+                "1-sigma uncertainty in the peak spectral "
+                "brightness of the source (Jy/beam)"
+            ),
+            "x": (
+                "x-position (float) of the barycenter of the source, "
+                "correponding to the row index of the Numpy array with "
+                "image data. After loading a FITS image, the data is "
+                "transposed such that x and y are aligned with ds9 viewing, "
+                "except for an offset of 1 pixel, since the bottom left "
+                "pixel in ds9 has x=y=1"
+            ),
+            "y": (
+                "y-position (float) of the barycenter of the source, "
+                "correponding to the column index of the Numpy array with "
+                "image data. After loading a FITS image, the data is "
+                "transposed such that x and y are aligned with ds9 viewing, "
+                "except for an offset of 1 pixel, since the bottom left "
+                "pixel in ds9 has x=y=1"
+            ),
+            "sig": (
+                "The significance of a detection (float) is defined as "
+                "the maximum signal-to-noise ratio across the island. "
+                "Often this will be the ratio of the maximum pixel value "
+                "of the source divided by the noise at that position."
+            ),
+            "reduced_chisq": (
+                "The reduced chi-squared value of the Gaussian "
+                "model relative to the data (float). Can be a "
+                "Gaussian model derived from a fit or from "
+                "moments. See the measuring.goodness_of_fit "
+                "docstring for some important notes."
+            ),
         }[self.value]
+
 
 _source_params = [p.value for p in SourceParam.__members__.values()]
 
@@ -194,136 +221,247 @@ _source_params = [p.value for p in SourceParam.__members__.values()]
 class ImgConf(_Validate):
     """Configuration that should cover all the specifications for processing the image."""
 
-    interpolate_order: int = 1  # Order of interpolation to use for
-    # the background mean and background standard deviation (rms) maps (e.g. 1
-    # for linear)
-    median_filter: int = 0      # Size of the median filter to apply to
-    # background and RMS grids prior to interpolating. This is used to
-    # discard outliers. Use 0 to disable.
-    mf_threshold: int = 0       # Threshold (Jy/beam) used with the median
-    # filter if median_filter is non-zero. This is used to only discard
-    # outliers (i.e. extreme background mean or rms node values) beyond a
-    # certain threshold. Use 0 to disable.
-    rms_filter: float = 0.001   # Any interpolated background standard
-    # deviation (rms) value should be above this threshold times the mean of
-    # all background standard deviation (rms) node values. This is used to
-    # avoid picking up sources towards the edges of the image where the values
-    # of the background rms map may be the result of poor interpolation,
-    # i.e. are the result of extrapolation rather than interpolation. Use 0 to
-    # disable.
-    deblend_mincont: float = 0.005  # Minimum flux density fraction (relative
-    # to the original, i.e. unblended, island) required for a subisland to be
-    # considered a valid deblended component.
+    interpolate_order: int = 1
+    """Order of interpolation to use for the background mean and
+    background standard deviation (rms) maps (e.g. 1 for linear)
 
-    # The "structuring element" defines island connectivity as in
-    # "4-connectivity" and "8-connectivity". These two are the only reasonable
-    # choices, since the structuring element must be centrosymmetric.
-    # The structuring element is applied in scipy.ndimage.label, so check its
-    # documentation for some background on its use.
+    """
+
+    median_filter: int = 0
+    """Size of the median filter to apply to background and RMS grids
+    prior to interpolating. This is used to discard outliers. Use 0 to
+    disable.
+
+    """
+
+    mf_threshold: int = 0
+    """Threshold (Jy/beam) used with the median filter if
+    median_filter is non-zero. This is used to only discard outliers
+    (i.e. extreme background mean or rms node values) beyond a certain
+    threshold. Use 0 to disable.
+
+    """
+
+    rms_filter: float = 0.001
+    """Any interpolated background standard deviation (rms) value
+    should be above this threshold times the mean of all background
+    standard deviation (rms) node values. This is used to avoid
+    picking up sources towards the edges of the image where the values
+    of the background rms map may be the result of poor interpolation,
+    i.e. are the result of extrapolation rather than
+    interpolation. Use 0 to disable.
+
+    """
+
+    deblend_mincont: float = 0.005
+    """Minimum flux density fraction (relative to the original,
+    i.e. unblended, island) required for a subisland to be considered
+    a valid deblended component.
+
+    """
+
     structuring_element: list[list[int]] = field(
         default_factory=lambda: _structuring_element
     )
-    vectorized: bool = False               # Measure sources in a vectorized
-    # way. Expect peak spectral brightnesses with a lower bias (downwards) than
-    # for Gaussian fits (also downwards), but with a higher bias (upwards
-    # for both) for the elliptical axes.
-    allow_multiprocessing: bool = True     # Allow multiprocessing for Gaussian
-    # fitting in parallel.
-    margin: int = 0                        # Margin in pixels to ignore around
-    # the edge of the image.
-    radius: float = 0.0                    # Radius in pixels (from
-    # image center around sources to include in analysis.
-    back_size_x: int | None = 32           # Subimage size for estimation of
-    # background node values (X direction). The nodes are centred on the
-    # subimages.
-    back_size_y: int | None = 32            # Subimage size for estimation of
-    # background node values (Y direction). The nodes are centred on the
-    # subimages.
-    eps_ra: float = 0.0                    # Calibration uncertainty in right
-    # ascension (degrees), see equation 27a of the NVSS paper.
-    eps_dec: float = 0.0                   # Calibration uncertainty in
-    # declination (degrees), see equation 27b of the NVSS paper.
-    detection: float = 10.0                # Detection threshold as multiple of
-    # the background standard deviation (rms) map, after the background mean
-    # values have been subtracted from the image.
-    analysis: float = 3.0                  # Analysis threshold as multiple of
-    # the background standard deviation (rms) map, after the background mean
-    # values have been subtracted from the image.
-    fdr: bool = False                      # Use False Detection Rate (FDR)
-    # algorithm for determining detection threshold.
-    alpha: float = 1e-2                    # FDR alpha value (float,
-    # default 0.01) that sets an upper limit on the fraction of pixels
-    # erroneously detected as source pixels, relative to all source pixels.
-    # This requirement should be met when averaged over a large ensemble of
-    # images, but problems were encountered with alpha as low as 0.001,
-    # see paragraph 3.6 of Spreeuw's thesis.
-    deblend_thresholds: int = 0            # Number of deblending
-    # subthresholds; 0 to disable.
-    grid: int | None = None                # Background subimage size used
-    # as fallback for back_size_x and back_size_y. If both are not set,
-    # this implies back_size_x=backsize_y=grid, i.e. the subimages are squares.
-    bmaj: float | None = None              # Set beam: Major axis of
-    # restoring beam (degrees).
-    bmin: float | None = None              # Set beam: Minor axis of
-    # restoring beam (degrees).
-    bpa: float | None = None               # Set beam: Restoring beam position
-    # angle (degrees).
-    force_beam: bool = False               # Force source shape to align
-    # restoring beam shape (bmaj, bmin, bpa) for Gauss fits and vetorized
-    # source measurement, i.e. when vectorized=True (as of 2025-06-13:
-    # upcoming, issue #131).
-    detection_image: str | None = None     # Path to detection map. PySE will
-    # identify sources and the positions of pixels which comprise them on the
-    # detection image, but then use the corresponding pixels on the target
-    # images to perform measurements. Of course, the detection image and
-    # the target image(s) must have the same pixel dimensions. Note that only
-    # a single detection image may be specified, and the same pixels are then
-    # used on all target images. Note further that this detection-image option
-    # is incompatible with --fdr
-    fixed_posns: str | None = None         # JSON __list__ of RA, Dec pairs of
-    # coordinates to measure sources at (disables blind extraction and
-    # vectorized source measurements).
-    fixed_posns_file: str | None = None    # Path to JSON file with RA, Dec
-    # pairs of coordinates to measure sources at (disables blind extraction
-    # and vectorized source measurements).
-    ffbox: float = 3.0                     # When fitting to a fixed position,
-    # a square “box” of pixels is chosen around the requested position, and the
-    # optimization procedure allows the source position to vary within that
-    # box. The size of the box may be changed with this option. Note that this
-    # parameter is given in units of the major axis of the beam in pixels.
-    ew_sys_err: float = 0.                 # Systematic error in east-west
-    # direction, see paragraph 5.2.3 of the NVSS paper. Note that this
-    # parameter is currently not applied in PySE, because it should be
-    # considered a final step before entering source parameters in a catalog,
-    # i.e. it is simply returned to allow for systematic positional offset
-    # cf. the NVSS. Therefore, its unit (degrees, arcseconds) is up to the
-    # user.
-    ns_sys_err: float = 0.                 # Systematic error in north-south
-    # direction, see paragraph 5.2.3 of the NVSS paper. Note that this
-    # parameter is currently not applied in PySE, because it should be
-    # considered a final step before entering source parameters in a catalog,
-    # i.e. it is simply returned to allow for systematic positional offset
-    # cf. the NVSS. Therefore, its unit (degrees, arcseconds) is up to the
-    # user.
+    """The "structuring element" defines island connectivity as in
+    "4-connectivity" and "8-connectivity". These two are the only
+    reasonable choices, since the structuring element must be
+    centrosymmetric.  The structuring element is applied in
+    scipy.ndimage.label, so check its documentation for some
+    background on its use.
 
+    """
+
+    vectorized: bool = False
+    """Measure sources in a vectorized way. Expect peak spectral
+    brightnesses with a lower bias (downwards) than for Gaussian fits
+    (also downwards), but with a higher bias (upwards for both) for
+    the elliptical axes.
+
+    """
+
+    allow_multiprocessing: bool = True
+    """Allow multiprocessing for Gaussian fitting in parallel."""
+
+    margin: int = 0
+    """Margin in pixels to ignore around the edge of the image."""
+
+    radius: float = 0.0
+    """Radius in pixels (from image center around sources to include
+    in analysis.
+
+    """
+
+    back_size_x: int | None = 32
+    """Subimage size for estimation of background node values (X
+    direction). The nodes are centred on the subimages.
+
+    """
+
+    back_size_y: int | None = 32
+    """Subimage size for estimation of background node values (Y
+    direction). The nodes are centred on the subimages.
+
+    """
+
+    eps_ra: float = 0.0
+    """Calibration uncertainty in right ascension (degrees), see
+    equation 27a of the NVSS paper.
+
+    """
+
+    eps_dec: float = 0.0
+    """Calibration uncertainty in declination (degrees), see equation
+    27b of the NVSS paper.
+
+    """
+
+    detection: float = 10.0
+    """Detection threshold as multiple of the background standard
+    deviation (rms) map, after the background mean values have been
+    subtracted from the image.
+
+    """
+
+    analysis: float = 3.0
+    """Analysis threshold as multiple of the background standard
+    deviation (rms) map, after the background mean values have been
+    subtracted from the image.
+
+    """
+
+    fdr: bool = False
+    """Use False Detection Rate (FDR) algorithm for determining
+    detection threshold.
+
+    """
+
+    alpha: float = 1e-2
+    """FDR alpha value (float, default 0.01) that sets an upper limit
+    on the fraction of pixels erroneously detected as source pixels,
+    relative to all source pixels.  This requirement should be met
+    when averaged over a large ensemble of images, but problems were
+    encountered with alpha as low as 0.001, see paragraph 3.6 of
+    Spreeuw's thesis.
+
+    """
+
+    deblend_thresholds: int = 0
+    """Number of deblending subthresholds; 0 to disable."""
+
+    grid: int | None = None
+    """Background subimage size used as fallback for back_size_x and
+    back_size_y. If both are not set, this implies
+    back_size_x=backsize_y=grid, i.e. the subimages are squares.
+
+    """
+
+    bmaj: float | None = None
+    """Set beam: Major axis of restoring beam (degrees)."""
+
+    bmin: float | None = None
+    """Set beam: Minor axis of restoring beam (degrees)."""
+
+    bpa: float | None = None
+    """Set beam: Restoring beam position angle (degrees)."""
+
+    force_beam: bool = False
+    """Force source shape to align restoring beam shape (bmaj, bmin,
+    bpa) for Gauss fits and vetorized source measurement, i.e. when
+    vectorized=True (as of 2025-06-13: upcoming, issue #131).
+
+    """
+
+    detection_image: str | None = None
+    """Path to detection map. PySE will identify sources and the
+    positions of pixels which comprise them on the detection image,
+    but then use the corresponding pixels on the target images to
+    perform measurements. Of course, the detection image and the
+    target image(s) must have the same pixel dimensions. Note that
+    only a single detection image may be specified, and the same
+    pixels are then used on all target images. Note further that this
+    detection-image option is incompatible with --fdr
+
+    """
+
+    fixed_posns: str | None = None
+    """JSON __list__ of RA, Dec pairs of coordinates to measure
+    sources at (disables blind extraction and vectorized source
+    measurements).
+
+    """
+
+    fixed_posns_file: str | None = None
+    """Path to JSON file with RA, Dec pairs of coordinates to measure
+    sources at (disables blind extraction and vectorized source
+    measurements).
+
+    """
+
+    ffbox: float = 3.0
+    """When fitting to a fixed position, a square “box” of pixels is
+    chosen around the requested position, and the optimization
+    procedure allows the source position to vary within that box. The
+    size of the box may be changed with this option. Note that this
+    parameter is given in units of the major axis of the beam in
+    pixels.
+
+    """
+
+    ew_sys_err: float = 0.0
+    """Systematic error in east-west direction, see paragraph 5.2.3
+    of the NVSS paper. Note that this parameter is currently not
+    applied in PySE, because it should be considered a final step
+    before entering source parameters in a catalog, i.e. it is simply
+    returned to allow for systematic positional offset cf. the
+    NVSS. Therefore, its unit (degrees, arcseconds) is up to the user.
+
+    """
+
+    ns_sys_err: float = 0.0
+    """Systematic error in north-south direction, see paragraph 5.2.3
+    of the NVSS paper. Note that this parameter is currently not
+    applied in PySE, because it should be considered a final step
+    before entering source parameters in a catalog, i.e. it is simply
+    returned to allow for systematic positional offset cf. the
+    NVSS. Therefore, its unit (degrees, arcseconds) is up to the user.
+
+    """
 
 
 @dataclass(frozen=True)
 class ExportSettings(_Validate):
     """Selection of output, related to detected sources and/or intermediate image processing products"""
 
-    output_dir: str = "."                   # Directory in which to write the output files
-    file_type: str = "csv"                  # Output file type (default: csv).
-    skymodel: bool = False                  # Generate sky model.
-    csv: bool = False                       # Generate CSV text file (e.g., for TopCat).
-    regions: bool = False                   # Generate DS9 region file(s).
-    rmsmap: bool = False                    # Generate RMS map.
-    sigmap: bool = False                    # Generate significance map.
-    residuals: bool = False                 # Generate residual maps.
-    islands: bool = False                   # Generate island maps.
-    source_params: list[str] = field(       # Source parameters to include in the output.
-        default_factory=lambda: _source_params
-    )
+    output_dir: str = "."
+    """Directory in which to write the output files."""
+
+    file_type: str = "csv"
+    """Output file type (default: csv)."""
+
+    skymodel: bool = False
+    """Generate sky model."""
+
+    csv: bool = False
+    """Generate CSV text file (e.g., for TopCat)."""
+
+    regions: bool = False
+    """Generate DS9 region file(s)."""
+
+    rmsmap: bool = False
+    """Generate RMS map."""
+
+    sigmap: bool = False
+    """Generate significance map."""
+
+    residuals: bool = False
+    """Generate residual maps."""
+
+    islands: bool = False
+    """Generate island maps."""
+
+    source_params: list[str] = field(default_factory=lambda: _source_params)
+    """Source parameters to include in the output."""
 
 
 @dataclass(frozen=True)
@@ -334,10 +472,11 @@ class Conf:
     def __post_init__(self):  # noqa: D105
         for key, field_t in get_type_hints(self).items():
             value = getattr(self, key)
-            if unguarded_is_dataclass(field_t) and isinstance(value, dict):
+            if _is_dataclass(field_t) and isinstance(value, dict):
                 # NOTE: have to do it like this since inherited
                 # dataclasses are frozen
                 super().__setattr__(key, field_t(**value))
+
 
 def normalize_none_values(val):
     if isinstance(val, dict):
@@ -348,6 +487,7 @@ def normalize_none_values(val):
         return None
     else:
         return val
+
 
 def read_conf(path: str | Path):
     data_raw = tomllib.loads(Path(path).read_text())

--- a/sourcefinder/deconv.py
+++ b/sourcefinder/deconv.py
@@ -1,14 +1,11 @@
-"""
-Gaussian deconvolution.
-"""
+"""Gaussian deconvolution."""
 
 from math import sin, cos, atan, sqrt, pi
 from numba import njit
 
 @njit
 def deconv(fmaj, fmin, fpa, cmaj, cmin, cpa):
-    """
-    Deconvolve a Gaussian "beam" from a Gaussian component.
+    """Deconvolve a Gaussian "beam" from a Gaussian component.
 
     When we fit an elliptical Gaussian to a point in our image, we are
     actually fitting to a convolution of the physical shape of the source with
@@ -43,6 +40,7 @@ def deconv(fmaj, fmin, fpa, cmaj, cmin, cpa):
         - real minor axis (float)
         - real position angle of the major axis (float)
         - number of components which failed to deconvolve (int)
+
     """
     HALF_RAD = 90.0 / pi
     cmaj2 = cmaj * cmaj

--- a/sourcefinder/extract.py
+++ b/sourcefinder/extract.py
@@ -1,7 +1,7 @@
-"""
-Source Extraction Helpers.
+"""Source Extraction Helpers.
 
 These are used in conjunction with image.ImageData.
+
 """
 
 from sourcefinder.deconv import deconv
@@ -33,8 +33,8 @@ BIGNUM = 99999.0
 
 
 class Island(object):
-    """
-    The source extraction process forms islands, which it then fits.
+    """The source extraction process forms islands, which it then fits.
+
     Each island needs to know its position in the image (ie, x, y pixel
     value at one corner), the threshold above which it is detected
     (analysis_threshold by default, but will increase if the island is
@@ -42,13 +42,15 @@ class Island(object):
 
     The island should provide a means of deblending: splitting itself
     apart and returning multiple sub-islands, if necessary.
+
     """
 
     def __init__(self, data, rms, chunk, analysis_threshold, detection_map,
                  beam, deblend_nthresh, deblend_mincont, structuring_element,
                  rms_orig=None, flux_orig=None, subthrrange=None
                  ):
-        """
+        """Initialise.
+
         Parameters
         ----------
         data : ndarray
@@ -88,6 +90,7 @@ class Island(object):
             The original flux value of the island.
         subthrrange : ndarray, default: None
             The subthreshold range for deblending.
+
         """
 
         # deblend_nthresh is the number of subthresholds used when deblending.
@@ -136,8 +139,7 @@ class Island(object):
             )
 
     def deblend(self, niter=0):
-        """
-        Decompose the island into subislands.
+        """Decompose the island into subislands.
     
         Parameters
         ----------
@@ -158,6 +160,7 @@ class Island(object):
         This function iterates up through subthresholds, looking for the island
         to split into two or more separate islands. If splitting occurs, the
         function starts again with the new subislands.
+
         """
         logger.debug("Deblending source")
         for level in self.subthrrange[niter:]:
@@ -255,24 +258,33 @@ class Island(object):
         return self
 
     def threshold(self):
-        """Threshold for island segmentation expressed as the rms noise at the
-        position of the island's pixel with the highest spectral brightness
-        times the analysis threshold."""
+        """Threshold for island segmentation.
+
+        It is expressed as the rms noise at the position of the
+        island's pixel with the highest spectral brightness times the
+        analysis threshold.
+
+        """
         return self.noise() * self.analysis_threshold
 
     def noise(self):
-        """Noise at position of the island pixel with the highest spectral
-        brightness."""
+        """Noise at position of the island pixel with the highest
+        spectral brightness.
+
+        """
         return self.rms[self.max_pos]
 
     def sig(self):
-        """Source significance expressed as the maximum signal-to-noise
-        across the island."""
+        """Source significance expressed as the maximum
+        signal-to-noise across the island.
+
+        """
         return (self.data / self.rms_orig).max()
 
     def fit(self, fudge_max_pix_factor, beamsize, correlation_lengths,
             fixed=None):
-        """
+        """Fit.
+
         Measure the source, i.e. compute its Gaussian parameters and the
         corresponding errors.
 
@@ -301,6 +313,7 @@ class Island(object):
             In those ndarrays masked (unfitted) regions have been filled with
             0-values, typically in the corners of the rectangular area
             encompassing the island.
+
         """
         try:
             measurement, gauss_island, gauss_residual = \
@@ -321,9 +334,10 @@ class Island(object):
 
 
 class ParamSet(MutableMapping):
-    """
-    All the source fitting methods should go to produce a ParamSet, which
-    gives all the information necessary to make a Detection.
+    """All the source fitting methods should go to produce a
+    ParamSet, which gives all the information necessary to make a
+    Detection.
+
     """
 
     def __init__(self, clean_bias=0.0, clean_bias_error=0.0,
@@ -401,14 +415,14 @@ class ParamSet(MutableMapping):
         return len(self.measurements)
 
     def keys(self):
-        """ """
         return list(self.measurements.keys())
 
     def compute_bounds(self, data_shape):
-        """
-        Calculate bounds for 'safer' Gauss fitting, i.e. a smaller chance on 
-        runaway solutions. The bounds are largely based on moments estimation,
-        so it only makes sense to impose bounds if moments estimation was 
+        """Calculate bounds for 'safer' Gauss fitting.
+
+        Here, 'safer' means a smaller chance on runaway solutions. The
+        bounds are largely based on moments estimation, so it only
+        makes sense to impose bounds if moments estimation was
         successful.
         
         Parameters
@@ -427,6 +441,7 @@ class ParamSet(MutableMapping):
             (float) and boolean elements. If the boolean is True, a bound will
             be loosened when the fit becomes unfeasible.  See the documentation
             on scipy.optimize.Bounds for details.
+
         """
         if hasattr(self["peak"], "value"):
             self.bounds["peak"] = (0.5 * self["peak"].value,
@@ -476,8 +491,7 @@ class ParamSet(MutableMapping):
         return self
 
     def calculate_errors(self, noise, correlation_lengths, threshold):
-        """
-        Calculate positional errors for the source parameters.
+        """Calculate positional errors for the source parameters.
 
         This method uses the Condon formulae if the object is based on a
         Gaussian fit, or error bars from moments if it's based on moments.
@@ -499,6 +513,7 @@ class ParamSet(MutableMapping):
         Returns
         -------
         An updated ParamSet instance
+
         """
         if self.gaussian:
             return self._condon_formulae(noise, correlation_lengths)
@@ -514,9 +529,10 @@ class ParamSet(MutableMapping):
                                                  threshold)
 
     def _condon_formulae(self, noise, correlation_lengths):
-        """
-        Returns the errors on parameters from Gaussian fits according to
-        the Condon (PASP 109, 166 (1997)) formulae.
+        """Returns the errors on parameters from Gaussian fits.
+
+        The errors are according to the Condon (PASP 109, 166 (1997))
+        formulae.
     
         These formulae are not perfect, but we'll use them for the
         time being.  (See Refregier and Brown (astro-ph/9803279v1) for
@@ -538,6 +554,7 @@ class ParamSet(MutableMapping):
         -------
         ParamSet
             The updated ParamSet instance with calculated errors.
+
         """
         peak = self['peak'].value
         flux = self['flux'].value
@@ -633,8 +650,7 @@ class ParamSet(MutableMapping):
 
     def _error_bars_from_moments(self, noise, correlation_lengths,
                                  threshold):
-        """
-        Provide reasonable error estimates from the moments.
+        """Provide reasonable error estimates from the moments.
 
         Parameters
         ----------
@@ -654,6 +670,7 @@ class ParamSet(MutableMapping):
         -------
         ParamSet
             The updated ParamSet instance with calculated errors.
+
         """
         # The formulae below should give some reasonable estimate of the
         # errors from moments, should always be higher than the errors from
@@ -744,8 +761,7 @@ class ParamSet(MutableMapping):
         return self
 
     def deconvolve_from_clean_beam(self, beam):
-        """
-        Deconvolve with the clean beam.
+        """Deconvolve with the clean beam.
 
         Parameters
         ----------
@@ -759,6 +775,7 @@ class ParamSet(MutableMapping):
             The updated ParamSet instance with deconvolved Gaussian shape
             parameters, i.e. the semi-major and semi-minor axes and the position
             angle.
+
         """
 
         # If the fitted axes are larger than the clean beam
@@ -874,8 +891,7 @@ class ParamSet(MutableMapping):
 def source_profile_and_errors(data, threshold, rms, noise, beam,
                               fudge_max_pix_factor, beamsize,
                               correlation_lengths, fixed=None):
-    """
-    Return a number of measurable properties with errorbars.
+    """Return a number of measurable properties with errorbars.
 
     Given an island of pixels it will return a number of measurable
     properties including errorbars. It will also compute residuals
@@ -935,6 +951,7 @@ def source_profile_and_errors(data, threshold, rms, noise, beam,
         corresponding contiguous region of the observational image (with mean
         background subtracted), which was segmented at the level of the analysis
         threshold.
+
     """
 
     if fixed is None:
@@ -1054,8 +1071,7 @@ def source_profile_and_errors(data, threshold, rms, noise, beam,
 
 
 class Detection(object):
-    """
-    Propagate a measurement in pixel space to celestial coordinates.
+    """Propagate a measurement in pixel space to celestial coordinates.
 
     A source measurement is primarily done in pixel space, this includes the
     parameters peak spectral brightness, position and (Gaussian) shape, but
@@ -1148,6 +1164,7 @@ class Detection(object):
         This is the same object passed as the `eps_ra` parameter.
     eps_dec : float, default: 0
         This is the same object passed as the `eps_dec` parameter.
+
     """
 
     def __init__(self, paramset, imagedata, chunk=None, eps_ra=0, eps_dec=0):
@@ -1243,7 +1260,9 @@ class Detection(object):
 
     def _physical_coordinates(self):
         """Convert the pixel parameters for this object into something
-        physical."""
+        physical.
+
+        """
 
         # First, the RA & dec.
         self.ra, self.dec = [Uncertain(x) for x in self.imagedata.wcs.p2s(
@@ -1418,16 +1437,18 @@ class Detection(object):
         self.smin_asec = Uncertain(smin_asec, errsmin_asec)
 
     def distance_from(self, x, y):
-        """Distance from center"""
+        """Distance from the center."""
         return ((self.x - x) ** 2 + (self.y - y) ** 2) ** 0.5
 
     def serialize(self, conf=Conf):
-        """
-        Return source properties suitable for database storage.
+        """Return source properties suitable for database storage.
 
         We manually add ew_sys_err, ns_sys_err as defined in conf.image.
 
-        returns: a list of tuples containing all relevant fields
+        Returns
+        -------
+        a list of tuples containing all relevant fields
+
         """
 
         def _get_param(param_name):
@@ -1469,8 +1490,9 @@ def first_part_of_celestial_coordinates(ra_dec, endy_ra_dec,
                                         xbar_ybar_error,
                                         xbar_ybar_smaj_smin_theta,
                                         dummy, return_values):
-    """
-    Similar to extract.Detection._physical_coordinates, but vectorized and
+    """First part of celestial coordinates.
+
+    Similar to func:`extract.Detection._physical_coordinates`, but vectorized and
     mainly the first part, until we need another call to wcs.all_pix2world,
     based on the output from this part.
     What we have learned from moments_enhanced is that measuring the islands
@@ -1517,6 +1539,7 @@ def first_part_of_celestial_coordinates(ra_dec, endy_ra_dec,
     None
         This method does not return anything. The results are stored in the
         return_values array.
+
     """
 
     ra, dec = ra_dec
@@ -1617,7 +1640,8 @@ def first_part_of_celestial_coordinates(ra_dec, endy_ra_dec,
              '(n, m), (n, m), (l), (n, m), (), (), (k) -> (k), (k), (k), ()')
 def insert_sources_and_noise(some_image, noise_map, inds, labelled_data, label,
                              npix, source, noise, xpos, ypos, min_width):
-    """
+    """Insert sources and noise.
+
     We want to copy the relevant source and noise data into input arrays for
     measuring.moments_enhanced. Simultaneously calculate the minimum width of
     each island; when determining source properties this is an important
@@ -1688,6 +1712,7 @@ def insert_sources_and_noise(some_image, noise_map, inds, labelled_data, label,
         'guvectorize() functions don’t return their result value: they take it
         as an array argument, which must be filled in by the function'. In this
         case source, noise, xpos, ypos and min_width will be filled with values.
+
     """
 
     image_chunk = some_image[inds[0]:inds[1], inds[2]:inds[3]]
@@ -1722,7 +1747,8 @@ def source_measurements_pixels_and_celestial_vectorised(num_islands, npixs,
                                                         beam, beamsize,
                                                         correlation_lengths,
                                                         eps_ra, eps_dec):
-    """
+    """Source measurements (vectorised).
+
     From islands of pixels above the analysis threshold with peaks above the
     detection threshold source parameters are extracted, including error bars.
     These quantities are transformed to celestial coordinates in a vectorized
@@ -1909,6 +1935,7 @@ def source_measurements_pixels_and_celestial_vectorised(num_islands, npixs,
         1D float32 array representing reduced chi-squared statistics reflecting
         an indication of the goodness-of-fit, equivalent to reduced_chisq as
         calculated in measuring.goodness_of_fit.
+
     """
     # This is the conditional route to the fastest algorithm for source
     # measurements, with no forced_beam and deblending options and no Gauss

--- a/sourcefinder/gaussian.py
+++ b/sourcefinder/gaussian.py
@@ -1,5 +1,5 @@
-"""
-Definition of a two dimensional elliptical Gaussian.
+"""Definition of a two dimensional elliptical Gaussian.
+
 """
 
 from numpy import exp, log, cos, sin

--- a/sourcefinder/image.py
+++ b/sourcefinder/image.py
@@ -1,6 +1,6 @@
-"""
-Some generic utility routines for number handling and
-calculating (specific) variances
+"""Some generic utility routines for number handling and calculating
+(specific) variances
+
 """
 
 import itertools
@@ -32,54 +32,51 @@ logger = logging.getLogger(__name__)
 class ImageData(object):
     """Encapsulates an image in terms of a numpy array + meta/headerdata.
 
-    This is your primary contact point for interaction with images: it icludes
-    facilities for source extraction and measurement, etc.
+    This is your primary contact point for interaction with images: it
+    icludes facilities for source extraction and measurement, etc.
+
+    Parameters
+    ----------
+    data : 2D np.ndarray
+        Observational image data. Must be a regular np.ndarray, since image
+        data read from e.g. a FITS file is not a MaskedArray.
+    beam : tuple
+        Clean beam specification as (semi-major axis, semi-minor axis,
+        position angle) with the axes in pixel coordinates and the position
+        angle in radians
+    wcs : utility.coordinates.wcs
+        World coordinate system specification, in our case it is always
+        about sky coordinates.
+    margin : int, default: 0
+        Margin applied to each edge of image (in pixels). Introduces a mask.
+    radius : float, default: 0
+        Radius of usable portion of image (in pixels). Introduces a mask.
+    back_size_x : int, default: 32
+        Subimage size along rows. Subimages are centered on the nodes of the
+        background grid and serve to derive the mean and standard deviation
+        of the background pixels.
+    back_size_y : int, default: 32
+        Subimage size along columns. Subimages are centered on the nodes of
+        the background grid and serve to derive the mean and standard
+        deviation of the background pixels.
+    residuals : bool, default: False
+        Whether to save Gaussian residuals, at the pixels corresponding to
+        the islands, as an image. Other pixel values will be zero.
+    islands : bool, default: False
+        Whether to save the Gaussian reconstructions, at the pixels
+        corresponding to the islands, as an image. Other pixel values will
+        be zero.
+    eps_ra : float, default: 0
+        Calibration uncertainty along Right Ascension in degrees.
+        See equation 27a of NVSS paper.
+    eps_dec : float, default: 0
+        Calibration uncertainty along Declination in degrees.
+        See equation 27b of NVSS paper.
+
     """
 
     def __init__(self, data, beam, wcs, conf: Conf = Conf(image=ImgConf(),
                  export=ExportSettings())):
-        """
-        Initializes an ImageData object.
-
-        Parameters
-        ----------
-        data : 2D np.ndarray
-            Observational image data. Must be a regular np.ndarray, since image
-            data read from e.g. a FITS file is not a MaskedArray.
-        beam : tuple
-            Clean beam specification as (semi-major axis, semi-minor axis,
-            position angle) with the axes in pixel coordinates and the position
-            angle in radians
-        wcs : utility.coordinates.wcs
-            World coordinate system specification, in our case it is always
-            about sky coordinates.
-        margin : int, default: 0
-            Margin applied to each edge of image (in pixels). Introduces a mask.
-        radius : float, default: 0
-            Radius of usable portion of image (in pixels). Introduces a mask.
-        back_size_x : int, default: 32
-            Subimage size along rows. Subimages are centered on the nodes of the
-            background grid and serve to derive the mean and standard deviation
-            of the background pixels.
-        back_size_y : int, default: 32
-            Subimage size along columns. Subimages are centered on the nodes of
-            the background grid and serve to derive the mean and standard
-            deviation of the background pixels.
-        residuals : bool, default: False
-            Whether to save Gaussian residuals, at the pixels corresponding to
-            the islands, as an image. Other pixel values will be zero.
-        islands : bool, default: False
-            Whether to save the Gaussian reconstructions, at the pixels
-            corresponding to the islands, as an image. Other pixel values will
-            be zero.
-        eps_ra : float, default: 0
-            Calibration uncertainty along Right Ascension in degrees.
-            See equation 27a of NVSS paper.
-        eps_dec : float, default: 0
-            Calibration uncertainty along Declination in degrees.
-            See equation 27b of NVSS paper.
-        """
-
         # Do data, wcs and beam need deepcopy?
         # Probably not (memory overhead, in particular for data),
         # but then the user shouldn't change them outside ImageData in the
@@ -208,6 +205,7 @@ class ImageData(object):
         data. All of these can be reconstructed from the data accessor.
 
         Note that this *must* be run to pick up any new settings.
+
         """
         try:
             self.labels.clear()
@@ -241,6 +239,7 @@ class ImageData(object):
 
         This is called automatically when ImageData.backmap,
         ImageData.rmsmap or ImageData.fdrmap is first accessed.
+
         """
 
         # there's no point in working with the whole of the data array
@@ -320,8 +319,8 @@ class ImageData(object):
 
     def _interpolate(self, grid, inds, roundup=False):
 
-        """
-        Interpolate a grid to produce a map of the dimensions of the image.
+        """Interpolate a grid to produce a map of the dimensions of
+        the image.
 
         Parameters
         ----------
@@ -342,6 +341,7 @@ class ImageData(object):
         This function is used to transform the RMS, background or FDR grids
         produced by :func:`_grids()` to a map we can compare with the image
         data.
+
         """
         # Use zeroes with the mask from the observational image as a starting
         # point for the mean background and rms background maps. Next, use
@@ -416,8 +416,8 @@ class ImageData(object):
     def extract(self, det, anl, noisemap=None, bgmap=None, labelled_data=None,
                 labels=None, deblend_nthresh=0, force_beam=False):
 
-        """
-        Kick off conventional (ie, rms island finding) source extraction.
+        """Kick off conventional (ie, rms island finding) source
+        extraction.
 
         Parameters
         ----------
@@ -451,6 +451,7 @@ class ImageData(object):
         Returns
         -------
         :class:`sourcefinder.utility.containers.ExtractionResults`
+
         """
         if anl > det:
             logger.warning(
@@ -510,6 +511,7 @@ class ImageData(object):
         data (background map, clips, etc.) is cleared before and after
         running this method. If this method is used frequently, a separate
         cache may be implemented in the future.
+
         """
         self.labels.clear()
         self.clip.clear()
@@ -520,11 +522,16 @@ class ImageData(object):
         self.clip.clear()
         return results
 
-    def fd_extract(self, alpha, anl=None, noisemap=None,
-                   bgmap=None, deblend_nthresh=0, force_beam=False
-                   ):
-        """
-        False Detection Rate based source extraction.
+    def fd_extract(
+        self,
+        alpha,
+        anl=None,
+        noisemap=None,
+        bgmap=None,
+        deblend_nthresh=0,
+        force_beam=False,
+    ):
+        """False Detection Rate based source extraction.
 
         The FDR procedure guarantees that the False Detection Rate (FDR) is less
         than alpha.
@@ -559,15 +566,17 @@ class ImageData(object):
         -----
         See Hopkins et al., AJ, 123, 1086 (2002) for more details.
         http://adsabs.harvard.edu/abs/2002AJ....123.1086H
+
         """
         # The correlation length in config.py is used not only for the
         # calculation of error bars with the Condon formulae, but also for
         # calculating the number of independent pixels.
         corlengthlong, corlengthshort = self.correlation_lengths
 
-        C_n = (1.0 / np.arange(
-            round(0.25 * np.pi * corlengthlong *
-                  corlengthshort + 1))[1:]).sum()
+        C_n = (
+            1.0
+            / np.arange(round(0.25 * np.pi * corlengthlong * corlengthshort + 1))[1:]
+        ).sum()
 
         # Calculate the FDR threshold
         # Things will go terribly wrong in the line below if the interpolated
@@ -589,15 +598,14 @@ class ImageData(object):
         normalized_data = self.data_bgsubbed / self.rmsmap
 
         n1 = np.sqrt(2 * np.pi)
-        prob = np.sort(
-            np.ravel(np.exp(-0.5 * normalized_data ** 2) / n1))
+        prob = np.sort(np.ravel(np.exp(-0.5 * normalized_data**2) / n1))
         lengthprob = float(len(prob))
         compare = (alpha / C_n) * np.arange(lengthprob + 1)[1:] / lengthprob
         # Find the last undercrossing, see, e.g., fig. 9 in Miller et al., AJ
         # 122, 3492 (2001).  Searchsorted is not used because the array is not
         # sorted.
         try:
-            index = (np.where(prob - compare < 0.)[0]).max()
+            index = (np.where(prob - compare < 0.0)[0]).max()
         except ValueError:
             # Everything below threshold
             return containers.ExtractionResults()
@@ -609,13 +617,18 @@ class ImageData(object):
         # See, e.g., Hopkins et al., AJ 123, 1086 (2002).
         if not anl:
             anl = fdr_threshold
-        return self._pyse(fdr_threshold * self.rmsmap, anl, anl * self.rmsmap,
-                          deblend_nthresh, force_beam)
+        return self._pyse(
+            fdr_threshold * self.rmsmap,
+            anl,
+            anl * self.rmsmap,
+            deblend_nthresh,
+            force_beam,
+        )
 
     @staticmethod
     def box_slice_about_pixel(x, y, box_radius):
-        """
-        Returns a slice centred about (x,y), of width = 2 * int(box_radius) + 1.
+        """Returns a slice centred about (x,y), of width = 2 *
+        int(box_radius) + 1.
 
         Parameters
         ----------
@@ -630,6 +643,7 @@ class ImageData(object):
         -------
         tuple of slice
             Slice centred about (x,y) with width = 2*box_radius + 1.
+
         """
         ibr = int(box_radius)
         x = int(x)
@@ -639,8 +653,8 @@ class ImageData(object):
 
     def fit_to_point(self, x: int, y: int, boxsize: int, threshold: float,
                      fixed: str):
-        """
-        Fit an elliptical Gaussian to a specified point on the image.
+        """Fit an elliptical Gaussian to a specified point on the
+        image.
 
         Parameters
         ----------
@@ -662,6 +676,7 @@ class ImageData(object):
         Detection
             An instance of :class:`sourcefinder.extract.Detection` containing
             the fit results.
+
         """
         logger.debug("Force-fitting pixel location ({},{})".format(x, y))
         # First, check that x and y are actually valid semi-positive integers.
@@ -776,8 +791,8 @@ class ImageData(object):
     def fit_fixed_positions(self, positions, boxsize, threshold=None,
                             fixed='position+shape',
                             ids=None):
-        """
-        Convenience function to fit a list of sources at the given positions.
+        """Convenience function to fit a list of sources at the given
+        positions.
 
         This function wraps around :py:func:`fit_to_point`.
 
@@ -805,6 +820,7 @@ class ImageData(object):
             A list of successful fits. If ``ids`` is None, returns a single list
             of :class:`sourcefinder.extract.Detection` s. Otherwise, returns a
             tuple of two matched lists: ([detections], [matching_ids]).
+
         """
         if ids is not None:
             assert len(ids) == len(positions)
@@ -847,8 +863,7 @@ class ImageData(object):
         return successful_fits
 
     def label_islands(self, detectionthresholdmap, analysisthresholdmap):
-        """
-        Return a labelled array of pixels for fitting.
+        """Return a labelled array of pixels for fitting.
 
         Parameters
         ----------
@@ -864,46 +879,56 @@ class ImageData(object):
         Returns
         -------
         tuple
-            A tuple containing:
-            labels_above_det_thr : np.ndarray
-                1D array of labels above detection threshold, with shape
-                (num_islands_above_detection_threshold,) and dtype np.int64.
-                Note that the length of this array may be smaller than the total
-                number of islands above the analysis threshold, as some labels
-                may have been filtered out due to a peak spectral brightness
-                lower than the local detection threshold.
-            labelled_data : np.ndarray
-                Array of labelled pixels, where each pixel with a nonzero label
-                corresponds to an island above the analysis threshold. The array
-                has the same shape as the observational image (self.rawdata) and
-                contains integer values corresponding to the labels of the
-                islands. Pixels that do not belong to any island are assigned a
-                label of 0. The number of islands above the analysis threshold
-                is equal to the number of unique labels in this array, which is
-                equal to or larger than num_islands_above_detection_threshold,
-                i.e. the number of islands above the detection threshold.
-                This array has dtype np.int32.
-            num_islands_above_detection_threshold : int
-                Number of islands above detection threshold.
-            maxposs_above_det_thr : np.ndarray
-                Array of indices of the maximum pixel values above detection
-                threshold, with shape (num_islands_above_detection_threshold, 2)
-                and dtype np.int32.
-            maxis_above_det_thr : np.ndarray
-                Array of maximum pixel values above detection threshold, with
-                shape (num_islands_above_detection_threshold,) and dtype
-                np.float32.
-            npixs_above_det : np.ndarray
-                1D array of pixel counts for each island with peak spectral
-                brightness above the detection threshold, with shape
-                (num_islands_above_detection_threshold,) and dtype np.int32.
-            all_indices_above_det_thr : np.ndarray
-                Array of indices of the islands above detection threshold, with
-                shape (num_islands_above_detection_threshold, 4) and dtype
-                np.int32.
-            slices : list of slice
-                List of slices encompassing all islands in labelled_data, i.e.
-                encompassing all islands above the analysis threshold.
+            - labels_above_det_thr (np.ndarray): 1D array of labels
+              above detection threshold, with shape
+              (num_islands_above_detection_threshold,) and dtype
+              np.int64.  Note that the length of this array may be
+              smaller than the total number of islands above the
+              analysis threshold, as some labels may have been
+              filtered out due to a peak spectral brightness lower
+              than the local detection threshold.
+
+            - labelled_data (np.ndarray): Array of labelled pixels,
+              where each pixel with a nonzero label corresponds to an
+              island above the analysis threshold. The array has the
+              same shape as the observational image (self.rawdata) and
+              contains integer values corresponding to the labels of
+              the islands. Pixels that do not belong to any island are
+              assigned a label of 0. The number of islands above the
+              analysis threshold is equal to the number of unique
+              labels in this array, which is equal to or larger than
+              num_islands_above_detection_threshold, i.e. the number
+              of islands above the detection threshold.  This array
+              has dtype np.int32.
+
+            - num_islands_above_detection_threshold (int): Number of
+              islands above detection threshold.
+
+            - maxposs_above_det_thr (np.ndarray): Array of indices of
+              the maximum pixel values above detection threshold, with
+              shape (num_islands_above_detection_threshold, 2) and
+              dtype np.int32.
+
+            - maxis_above_det_thr (np.ndarray): Array of maximum pixel
+              values above detection threshold, with shape
+              (num_islands_above_detection_threshold,) and dtype
+              np.float32.
+
+            - npixs_above_det (np.ndarray): 1D array of pixel counts
+              for each island with peak spectral brightness above the
+              detection threshold, with shape
+              (num_islands_above_detection_threshold,) and dtype
+              np.int32.
+
+            - all_indices_above_det_thr (np.ndarray): Array of indices
+              of the islands above detection threshold, with shape
+              (num_islands_above_detection_threshold, 4) and dtype
+              np.int32.
+
+            - slices (list): List of slices encompassing all islands
+              in labelled_data, i.e.  encompassing all islands above
+              the analysis threshold.
+
         """
         # If there is no usable data, we return an empty set of islands.
         if not len(self.rmsmap.compressed()):
@@ -992,8 +1017,10 @@ class ImageData(object):
     @staticmethod
     def fit_islands(fudge_max_pix_factor, beamsize, correlation_lengths,
                     fixed, island):
-        """This function was created to enable the use of 'partial' such that
-        we can parallellize source measurements"""
+        """This function was created to enable the use of 'partial'
+        such that we can parallellize source measurements
+
+        """
         return island.fit(fudge_max_pix_factor, beamsize, correlation_lengths,
                           fixed=fixed)
 
@@ -1004,10 +1031,12 @@ class ImageData(object):
     @staticmethod
     def slices_to_indices(slices):
         """Convert the list of tuples of slices generated by
-        scipy.ndimage.find_objects into a 2D int32 array with number of rows
-        equal to the number of islands and 4 columns, i.e 4 integers per island,
-        containing the same information as the slices, but more suitable for
-        compilation by Numba"""
+        scipy.ndimage.find_objects into a 2D int32 array with number
+        of rows equal to the number of islands and 4 columns, i.e 4
+        integers per island, containing the same information as the
+        slices, but more suitable for compilation by Numba
+
+        """
         num_slices = len(slices)
         all_indices = np.empty((num_slices, 4), dtype=np.int32)
 
@@ -1025,7 +1054,8 @@ class ImageData(object):
                  '(), (k) -> (k), (), ()')
     def extract_parms_image_slice(some_image, inds, labelled_data, label, dummy,
                                   maxpos, maxi, npix):
-        """
+        """Find the highest pixel value and its position.
+
         For an island, indicated by a group of pixels with the same label,
         find the highest pixel value and its position, first relative to the
         upper left corner of the rectangular slice encompassing the island,
@@ -1075,6 +1105,7 @@ class ImageData(object):
             'guvectorize() functions don’t return their result value: they take
             it as an array argument, which must be filled in by the function'. In
             this case maxpos, maxi and npix will be filled with values.
+
         """
 
         labelled_data_chunk = labelled_data[inds[0]:inds[1], inds[2]:inds[3]]
@@ -1094,8 +1125,7 @@ class ImageData(object):
             self, detectionthresholdmap, analysis_threshold,
             analysisthresholdmap, deblend_nthresh, force_beam,
             labelled_data=None, labels=np.array([], dtype=np.int32)):
-        """
-        Run Python-based source extraction on this image.
+        """Run Python-based source extraction on this image.
 
         Parameters
         ----------
@@ -1139,6 +1169,7 @@ class ImageData(object):
         This is described in detail in the "LOFAR Transients Pipeline" article
         by John D. Swinbank et al., see
         https://doi.org/10.1016/j.ascom.2015.03.002
+
         """
         # Map our chunks onto a list of islands.
 
@@ -1305,10 +1336,12 @@ class ImageData(object):
                 results.append(det)
 
         def is_usable(det):
-            """
-            Check that both ends of each axis are usable; that is, that they
-            fall within an unmasked part of the image. The axis will not likely
-            fall exactly on a pixel number, so check all the surroundings.
+            """Check that both ends of each axis are usable.
+
+            I.e., they fall within an unmasked part of the image. The
+            axis will not likely fall exactly on a pixel number, so
+            check all the surroundings.
+
             """
             def check_point(x, y):
                 x = (int(x), int(np.ceil(x)))

--- a/sourcefinder/measuring.py
+++ b/sourcefinder/measuring.py
@@ -1,5 +1,5 @@
-"""
-Source measuring routines.
+"""Source measuring routines.
+
 """
 
 import math

--- a/sourcefinder/testutil/decorators.py
+++ b/sourcefinder/testutil/decorators.py
@@ -3,8 +3,8 @@ import unittest
 
 
 def requires_database():
-    """
-    Decorator to skip a test if database functionality is disabled.
+    """Decorator to skip a test if database functionality is
+    disabled.
 
     This function checks the environment variable `TKP_DISABLEDB`. If it is set
     to a truthy value, the test is skipped with an appropriate message.
@@ -13,6 +13,7 @@ def requires_database():
     -------
     function
         A decorator that either skips the test or allows it to run.
+
     """
     if os.environ.get("TKP_DISABLEDB", False):
         return unittest.skip("Database functionality disabled in configuration")
@@ -20,8 +21,8 @@ def requires_database():
 
 
 def requires_data(*args):
-    """
-    Decorator to skip a test if required data files are not available.
+    """Decorator to skip a test if required data files are not
+    available.
 
     This function checks for the existence of the specified data files.
     If any of the files do not exist, the test is skipped with an appropriate
@@ -36,6 +37,7 @@ def requires_data(*args):
     -------
     function
         A decorator that either skips the test or allows it to run.
+
     """
     for filename in args:
         if not os.path.exists(filename):
@@ -44,8 +46,8 @@ def requires_data(*args):
 
 
 def requires_module(module_name):
-    """
-    Decorator to skip a test if a required module is not available.
+    """Decorator to skip a test if a required module is not
+    available.
 
     This function attempts to import the specified module. If the module
     cannot be imported, the test is skipped with an appropriate message.
@@ -59,6 +61,7 @@ def requires_module(module_name):
     -------
     function
         A decorator that either skips the test or allows it to run.
+
     """
     try:
         __import__(module_name)
@@ -68,14 +71,13 @@ def requires_module(module_name):
 
 
 def duration(test_duration):
-    """
-    Decorator to skip a test if its duration exceeds the maximum allowed
-    duration.
+    """Decorator to skip a test if its duration exceeds the maximum
+    allowed duration.
 
-    This function checks the environment variable `TKP_MAXTESTDURATION` to
-    determine
-    the maximum allowed test duration. If the test's duration exceeds this
-    value, the test is skipped with an appropriate message.
+    This function checks the environment variable
+    ``TKP_MAXTESTDURATION`` to determine the maximum allowed test
+    duration. If the test's duration exceeds this value, the test is
+    skipped with an appropriate message.
 
     Parameters
     ----------
@@ -86,6 +88,7 @@ def duration(test_duration):
     -------
     function
         A decorator that either skips the test or allows it to run.
+
     """
     max_duration = float(os.environ.get("TKP_MAXTESTDURATION", False))
     if max_duration:
@@ -97,23 +100,27 @@ def duration(test_duration):
 
 
 def requires_test_db_managed():
-    """
-    Decorator to disable tests that perform potentially low-level database
-    management operations, such as destroying and creating databases.
+    """Decorator to disable tests that perform potentially low-level
+    database management operations, such as destroying and creating
+    databases.
 
     This decorator checks the environment variables to determine whether
     such tests should be enabled or skipped:
-    - If the `TKP_DBENGINE` environment variable is set to 'monetdb', the
-      test is skipped because database management tests are not supported
-      for MonetDB and must be tested manually.
-    - If the `TKP_TESTDBMANAGEMENT` environment variable is set, the test
-      is allowed to run.
+
+    - If the ``TKP_DBENGINE`` environment variable is set to
+      'monetdb', the test is skipped because database management tests
+      are not supported for MonetDB and must be tested manually.
+
+    - If the ``TKP_TESTDBMANAGEMENT`` environment variable is set, the
+      test is allowed to run.
+
     - Otherwise, the test is skipped with an appropriate message.
 
     Returns
     -------
     function
         A decorator that either skips the test or allows it to run.
+
     """
     if os.environ.get('TKP_DBENGINE', 'postgresql') == 'monetdb':
         return unittest.skip("DB management tests not supported for Monetdb,"

--- a/sourcefinder/utility/containers.py
+++ b/sourcefinder/utility/containers.py
@@ -1,8 +1,8 @@
-"""
-Container classes for the TKP pipeline.
+"""Container classes for the TKP pipeline.
 
 These provide convenient means of marshalling the various types of data --
 lightcurves, detections, sources, etc -- that the pipeline must handle.
+
 """
 
 import logging

--- a/sourcefinder/utils.py
+++ b/sourcefinder/utils.py
@@ -17,9 +17,9 @@ numba_config.THREADING_LAYER = 'workqueue'
 
 
 def generate_subthresholds(min_value, max_value, num_thresholds):
-    r"""
-    Generate a series of ``num_thresholds`` logarithmically spaced values
+    r"""Generate a series of ``num_thresholds`` logarithmically spaced values
     in the range (min_value, max_value) (both exclusive).
+
     First, we calculate a logarithmically spaced sequence between exp(0.0)
     and (max_value - min_value + 1). That is, the total range is between 1 and
     one greater than the difference between max_value and min_value.
@@ -52,22 +52,22 @@ def generate_subthresholds(min_value, max_value, num_thresholds):
     np.ndarray
         An array of logarithmically spaced values between min_value and
         max_value (exclusive).
+
     """
     subthrrange = np.logspace(
         0.0,
         np.log(max_value + 1 - min_value),
         num=num_thresholds + 1,  # first value == min_value
         base=np.e,
-        endpoint=False  # do not include max_value
+        endpoint=False,  # do not include max_value
     )[1:]
-    subthrrange += (min_value - 1)
+    subthrrange += min_value - 1
     return subthrrange
 
 
 def get_error_radius(wcs, x_value, x_error, y_value, y_error):
-    """
-    Estimate an absolute angular error on the position (x_value, y_value)
-    with the given errors.
+    """Estimate an absolute angular error on the position (x_value,
+    y_value) with the given errors.
 
     Parameters
     ----------
@@ -96,6 +96,7 @@ def get_error_radius(wcs, x_value, x_error, y_value, y_error):
     along the X and Y axes. Better might be to project them both back on
     to the major/minor axes of the elliptical fit, but this should do for
     now.
+
     """
     error_radius = 0.0
     try:
@@ -122,9 +123,9 @@ def get_error_radius(wcs, x_value, x_error, y_value, y_error):
 
 
 def circular_mask(xdim, ydim, radius):
-    """
-    Returns a numpy array of shape (xdim, ydim). All points within radius from
-    the centre are set to 0; outside that region, they are set to 1.
+    """Returns a numpy array of shape (xdim, ydim). All points within
+    radius from the centre are set to 0; outside that region, they are
+    set to 1.
     
     Parameters
     ----------
@@ -139,7 +140,8 @@ def circular_mask(xdim, ydim, radius):
     -------
     np.ndarray
         A 2D ndarray with points within the radius set to 0 and outside set to
-        1. 
+        1.
+
     """
     centre_x, centre_y = (xdim - 1) / 2.0, (ydim - 1) / 2.0
     x, y = np.ogrid[-centre_x: xdim - centre_x, -centre_y: ydim - centre_y]
@@ -169,6 +171,7 @@ def generate_result_maps(data, sourcelist):
         - The first array shows the Gaussian reconstructions of the sources.
         - The second array shows the residuals from the subtractions of these
           reconstructions from the image data.
+
     """
     residual_map = np.array(data)  # array constructor copies by default
     gaussian_map = np.zeros(residual_map.shape)
@@ -247,6 +250,7 @@ def calculate_correlation_lengths(semimajor, semiminor):
     tuple of float
         A tuple containing the correlation lengths (theta_B, theta_b), in
         pixels.
+
     """
 
     return 2.0 * semimajor, 2.0 * semiminor
@@ -312,6 +316,7 @@ def fudge_max_pix(semimajor, semiminor, theta):
     -------
     correction: float
         The estimated peak spectral brightness correction.
+
     """
 
     log20 = np.log(2.0)
@@ -355,6 +360,7 @@ def flatten(nested_list):
     Notes
     -----
         The keyword "yield" is used; i.e. a generator object is returned.
+
     """
 
     for elem in nested_list:
@@ -369,8 +375,8 @@ def flatten(nested_list):
 # Its AI-output has been verified for correctness, accuracy and
 # completeness, adapted where needed, and approved by the author.”
 def nearest_nonzero(some_arr, rms):
-    """
-    Replace values in some_arr based on the nearest non-zero values in rms.
+    """Replace values in some_arr based on the nearest non-zero
+    values in rms.
 
     Parameters
     ----------
@@ -385,6 +391,7 @@ def nearest_nonzero(some_arr, rms):
     np.ndarray
         A copy of some_arr with values replaced based on nearest non-zero
         neighbors in rms.
+
     """
     if some_arr.shape != rms.shape:
         raise ValueError("some_arr and rms must have the same shape.")
@@ -426,7 +433,8 @@ def nearest_nonzero(some_arr, rms):
 # completeness, adapted where needed, and approved by the author.”
 @njit(parallel=True)
 def make_subimages(a_data, a_mask, back_size_x, back_size_y):
-    """
+    """Make subimages.
+
     Reshape the image data such that it is suitable for guvectorized
     kappa * sigma clipping. The idea is that we have designed a function
     that will perform kappa * sigma clipping on a single flattened subimage,
@@ -436,18 +444,26 @@ def make_subimages(a_data, a_mask, back_size_x, back_size_y):
     kappa * sigma clipper should be 3D. This function makes that 3D input,
     which is essentially a reshape using Numba with parallelization.
 
-    Parameters:
-    a_data (np.ndarray): The data of the masked array (without the mask).
-    a_mask (np.ndarray): The mask of the masked array (True means the value
-                         is masked).
-    back_size_x (int): The size of the subimage along the row indices.
-    back_size_y (int): The size of the subimages along the column indices.
+    Parameters
+    ----------
+    a_data: np.ndarray
+        The data of the masked array (without the mask).
+    a_mask: np.ndarray
+        The mask of the masked array (True means the value is masked).
+    back_size_x: int
+        The size of the subimage along the row indices.
+    back_size_y: int
+        The size of the subimages along the column indices.
 
-    Returns:
-    b (np.ndarray): 3D array where each subimage of size (back_size_x *
-                    back_size_y) is flattened and padded with NaN.
-    c (np.ndarray): 2D array where each element indicates the number of
-                    unmasked values in the corresponding subimage.
+    Returns
+    -------
+    b: np.ndarray
+        3D array where each subimage of size (back_size_x *
+        back_size_y) is flattened and padded with NaN.
+    c: np.ndarray
+        2D array where each element indicates the number of unmasked
+        values in the corresponding subimage.
+
     """
     subimage_size = back_size_x * back_size_y
     k, l = a_data.shape
@@ -496,14 +512,20 @@ def make_subimages(a_data, a_mask, back_size_x, back_size_y):
     "(n),(n),(k)->(k)", 
     target="parallel", nopython=True, cache=True)
 def interp_per_row(grid_row, y_initial, y_sought, interp_row):
-    """
-    Interpolate one row of the grid along the second dimension (y-axis).
+    """Interpolate one row of the grid along the second dimension
+    (y-axis).
 
-    Parameters:
-    - grid_row: 1D array representing a single row of the grid.
-    - y_initial: Original grid coordinates along the y-axis.
-    - y_sought: Target coordinates for interpolation along the y-axis.
-    - interp_row: Output array to store the interpolated row.
+    Parameters
+    ----------
+    grid_row
+        1D array representing a single row of the grid.
+    y_initial
+        Original grid coordinates along the y-axis.
+    y_sought
+        Target coordinates for interpolation along the y-axis.
+    interp_row
+        Output array to store the interpolated row.
+
     """
     interp_row[:] = np.interp(y_sought, y_initial, grid_row)
 
@@ -512,16 +534,19 @@ def interp_per_row(grid_row, y_initial, y_sought, interp_row):
 # Its AI-output has been verified for correctness, accuracy and
 # completeness, adapted where needed, and approved by the author.”
 def two_step_interp(grid, new_xdim, new_ydim):
-    """
-    Perform two-step interpolation on a grid to upsample it to new dimensions.
-    This function proivdes fast pieceswise bilinear interpolation in two steps:
-    1) Interpolation across columns, i.e. per row of the input grid. Each row
-    of the input grid is handled independently.
-    2) Transpose the result.
-    3) Again, interpolate across columns.
-    This method was inspired by a comment from "tiago" in this SO discussion:
-    https://stackoverflow.com/questions/14530556/
-    resampling-a-numpy-array-representing-an-image
+    """Perform two-step interpolation.
+
+    It is done on a grid to upsample it to new dimensions.  This
+    function proivdes fast pieceswise bilinear interpolation in two
+    steps:
+
+    1. Interpolation across columns, i.e. per row of the input
+       grid. Each row of the input grid is handled independently.
+    2. Transpose the result.
+    3. Again, interpolate across columns.
+
+    This method was inspired by a comment from "tiago" in this SO
+    discussion: https://stackoverflow.com/q/14530556
 
     Parameters
     ----------
@@ -536,6 +561,7 @@ def two_step_interp(grid, new_xdim, new_ydim):
     -------
     numpy.ndarray
         The upsampled grid with dimensions (new_xdim, new_ydim).
+
     """
     # Define the main function for upsampling
     # Original grid coordinates
@@ -569,9 +595,8 @@ def two_step_interp(grid, new_xdim, new_ydim):
 @njit
 def newton_raphson_root_finder(f, sigma0, min_sigma, max_sigma,
                                tol=1e-8, max_iter=100, *args):
-    """
-    Solve the transcendental equation for sigma using Newton's method with
-    interval safeguards.
+    """Solve the transcendental equation for sigma using Newton's
+    method with interval safeguards.
 
     Parameters
     ----------
@@ -614,6 +639,7 @@ def newton_raphson_root_finder(f, sigma0, min_sigma, max_sigma,
     method terminates when the absolute change in sigma is smaller than the
     specified tolerance `tol` or when the maximum number of iterations is
     reached. If the derivative is too small (near zero), a ValueError is raised.
+
     """
 
     sigma = sigma0
@@ -646,10 +672,10 @@ def newton_raphson_root_finder(f, sigma0, min_sigma, max_sigma,
 
 
 def complement_gaussian_args(initial_params, fixed_params, fit_params):
-    """
-    Complements initial parameters for Gaussian fitting, with fixed values.
-    The end result should be a list of six elements, corresponding to 'peak',
-    'xbar', 'ybar', 'semimajor', 'semiminor' and 'theta', in that order
+    """Complements initial parameters for Gaussian fitting, with
+    fixed values.  The end result should be a list of six elements,
+    corresponding to 'peak', 'xbar', 'ybar', 'semimajor', 'semiminor'
+    and 'theta', in that order
 
     Parameters
     ----------
@@ -686,6 +712,7 @@ def complement_gaussian_args(initial_params, fixed_params, fit_params):
     ...               'semi-minor axis', 'position angle')
     >>> complement_gaussian_args(initial_parms, fixed_parms, fit_parms)
     [1.0, 2.5, 3.5, 4.0, 5.0, 6.0]
+
     """
     paramlist = list(initial_params)
     gaussian_args = []


### PR DESCRIPTION
- API docs using autoapi, theme: Furo
- also fix oldest supported test env

### Future tasks

Doesn't really need to be addressed in this PR, can be done gradually later; many of the docstrings have formatting that isn't standard.  Basically it should conform to [`numpydoc` format](https://numpydoc.readthedocs.io/en/latest/format.html).