### PR TITLE
Reduce test runtime by ~45%

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -67,10 +67,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install hatch
-          hatch env create test
+          hatch env create default
+          hatch env create test.py${{matrix.python-version}}
       - name: Run pytest
         run: |
-          hatch run test:pytest
+          hatch run +py=${{matrix.python-version}} test:pytest
       - name: Integration test
         run: |
           hatch run pyse --config-file test/data/config.toml --detection 5 --radius 400 --csv --force-beam test/data/GRB120422A-120429.fits

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.10", "3.13"]
         # lint with min & max supported versions
 
     steps:
@@ -79,7 +79,7 @@ jobs:
   type-check:
     strategy:
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.10", "3.13"]
 
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,34 @@ this:
    │         │         │ mypy         │
    │         │         │ ruff         │
    └─────────┴─────────┴──────────────┘
+                        Matrices
+   ┏━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┓
+   ┃ Name ┃ Type    ┃ Envs        ┃ Dependencies     ┃
+   ┡━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━┩
+   │ test │ virtual │ test.py3.10 │ pytest           │
+   │      │         │ test.py3.11 │ pytest-cov       │
+   │      │         │ test.py3.12 │                  │
+   │      │         │ test.py3.13 │                  │
+   └──────┴─────────┴─────────────┴──────────────────┘
+
+As shown above, the test environments also define a matrix to cover
+multiple Python versions.  So we can run the whole test matrix locally
+with:
+
+.. code-block:: bash
+
+   $ hatch run test:pytest
+
+Instead if you want to run only a subset, you can limit the python
+versions like this:
+
+.. code-block:: bash
+
+   $ hatch run +py=3.13 test:pytest # +py and +python are equivalent
+   $ hatch run +python=3.13 test:pytest
+   $ hatch run +python=3.12,3.13 test:pytest
+
+For more options, see ``hatch env run -h``.
 
 Some common tasks using ``hatch`` are summarised below.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ packages = ["sourcefinder"]
 
 [tool.hatch.envs.test]
 matrix = [
-    {python = ["3.12"]}
+    {python = ["3.10", "3.11", "3.12", "3.13"]}
 ]
 extra-dependencies = [
     "pytest",

--- a/test/test_L15_12h_const.py
+++ b/test/test_L15_12h_const.py
@@ -146,17 +146,21 @@ class L15_12hConstMod(unittest.TestCase):
 
 
 class FitToPointTestCase(unittest.TestCase):
-    def setUp(self):
+    __slots__ = ("my_im",)
+
+    @classmethod
+    def setUpClass(cls):
         # FWHM of PSF taken from fit to unresolved source.
         fitsfile = sourcefinder.accessors.fitsimage.FitsImage(corrected_fits,
                                                               beam=(2. * 500.099 / 3600,
                                                                     2. * 319.482 / 3600,
                                                                     168.676))
-        self.my_im = image.ImageData(fitsfile.data, fitsfile.beam,
+        cls.my_im = image.ImageData(fitsfile.data, fitsfile.beam,
                                      fitsfile.wcs)
 
-    def tearDown(self):
-        del self.my_im
+    @classmethod
+    def tearDownClass(cls):
+        del cls.my_im
         gc.collect()
 
     @requires_data(corrected_fits)

--- a/test/test_L15_12h_const.py
+++ b/test/test_L15_12h_const.py
@@ -1,6 +1,4 @@
-"""
-Tests for simulated LOFAR datasets.
-"""
+"""Tests for simulated LOFAR datasets."""
 
 import gc
 import os

--- a/test/test_L15_12h_const.py
+++ b/test/test_L15_12h_const.py
@@ -30,21 +30,25 @@ all_fits = os.path.join(DATAPATH, 'model-all.fits')
 
 
 class L15_12hConstObs(unittest.TestCase):
+    __slots__ = ("image", "results")
+
     # Single, constant 1 Jy source at centre of image.
     @requires_data(observed_fits)
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         # Beam here is derived from a Gaussian fit to the central (unresolved)
         # source.
         fitsfile = sourcefinder.accessors.fitsimage.FitsImage(observed_fits,
                                                               beam=(0.2299,
                                                                     0.1597,
                                                                     -23.87))
-        self.image = image.ImageData(fitsfile.data, fitsfile.beam, fitsfile.wcs)
-        self.results = self.image.extract(det=10, anl=3.0)
+        cls.image = image.ImageData(fitsfile.data, fitsfile.beam, fitsfile.wcs)
+        cls.results = cls.image.extract(det=10, anl=3.0)
 
-    def tearDown(self):
-        del self.results
-        del self.image
+    @classmethod
+    def tearDownClass(cls):
+        del cls.results
+        del cls.image
         gc.collect()
 
     @requires_data(observed_fits)
@@ -58,20 +62,24 @@ class L15_12hConstObs(unittest.TestCase):
 
 
 class L15_12hConstCor(unittest.TestCase):
+    __slots__ = ("image", "results")
+
     # Cross shape of 5 sources, 2 degrees apart, at centre of image.
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         # Beam here is derived from a Gaussian fit to the central (unresolved)
         # source.
         fitsfile = sourcefinder.accessors.fitsimage.FitsImage(corrected_fits,
                                                               beam=(0.2299,
                                                                     0.1597,
                                                                     -23.87))
-        self.image = image.ImageData(fitsfile.data, fitsfile.beam, fitsfile.wcs)
-        self.results = self.image.extract(det=10.0, anl=3.0)
+        cls.image = image.ImageData(fitsfile.data, fitsfile.beam, fitsfile.wcs)
+        cls.results = cls.image.extract(det=10.0, anl=3.0)
 
-    def tearDown(self):
-        del self.image
-        del self.results
+    @classmethod
+    def tearDownClass(cls):
+        del cls.image
+        del cls.results
         gc.collect()
 
     @requires_data(corrected_fits)
@@ -99,8 +107,11 @@ class L15_12hConstCor(unittest.TestCase):
 
 
 class L15_12hConstMod(unittest.TestCase):
+    __slots__ = ("image", "results")
+
     # 1 Jy constant source at centre; 1 Jy (peak) transient 3 degrees away.
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         # This image is of the whole sequence, so obviously we won't see the
         # transient varying. In fact, due to a glitch in the simulation
         # process, it will appear smeared out & shouldn't be identified at
@@ -111,14 +122,15 @@ class L15_12hConstMod(unittest.TestCase):
                                                               beam=(0.2299,
                                                                     0.1597,
                                                                     -23.87))
-        self.image = image.ImageData(
+        cls.image = image.ImageData(
             fitsfile.data, fitsfile.beam, fitsfile.wcs, Conf(ImgConf(radius=100), {})
         )
-        self.results = self.image.extract(det=5, anl=3.0)
+        cls.results = cls.image.extract(det=5, anl=3.0)
 
-    def tearDown(self):
-        del (self.results)
-        del (self.image)
+    @classmethod
+    def tearDownClass(cls):
+        del cls.results
+        del cls.image
         gc.collect()
 
     @requires_data(all_fits)

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -505,10 +505,17 @@ class TestNegationImage(unittest.TestCase):
     Check if we do not detect any sources from the negation of a Stokes I
     image with many sources.
     """
-    def setUp(self):
+    __slots__ = ("img",)
+
+    @classmethod
+    def setUpClass(cls):
         fitsfile = sourcefinder.accessors.open(os.path.join(DATAPATH,
                                                             'deconvolved.fits'))
-        self.img = ImageData(fitsfile.data, fitsfile.beam, fitsfile.wcs)
+        cls.img = ImageData(fitsfile.data, fitsfile.beam, fitsfile.wcs)
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.img
 
     @requires_data(os.path.join(DATAPATH, 'deconvolved.fits'))
     def testReverseSE(self):
@@ -530,15 +537,22 @@ class TestNegationImage(unittest.TestCase):
 # ChatGPT 4.0. All AI-output has been verified for correctness,
 # accuracy and completeness, adapted where needed, and approved by the author.
 class TestBackgroundCharacteristicsSimple(unittest.TestCase):
-    def setUp(self):
+    __slots__ = ("img",)
+
+    @classmethod
+    def setUpClass(cls):
         fitsfile = sourcefinder.accessors.open(os.path.join(DATAPATH,
                                                             'deconvolved.fits'))
-        self.img = sfimage.ImageData(
+        cls.img = ImageData(
             fitsfile.data,
             fitsfile.beam,
             fitsfile.wcs,
             Conf(ImgConf(back_size_x=128, back_size_y=51), {}),
         )
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.img
 
     @requires_data(os.path.join(DATAPATH + "/kappa_sigma_clipping",
                                 "mean_grid_deconvolved.fits.npy"),
@@ -612,15 +626,22 @@ class TestBackgroundCharacteristicsSimple(unittest.TestCase):
 # ChatGPT 4.0. All AI-output has been verified for correctness,
 # accuracy and completeness, adapted where needed, and approved by the author.
 class TestBackgroundCharacteristicsComplex(unittest.TestCase):
-    def setUp(self):
+    __slots__ = ("img",)
+
+    @classmethod
+    def setUpClass(cls):
         fitsfile = sourcefinder.accessors.open(os.path.join(DATAPATH,
                                                'image_206-215-t0002.fits'))
-        self.img = sfimage.ImageData(
+        cls.img = ImageData(
             fitsfile.data,
             (0.208, 0.136, 15.619),
             fitsfile.wcs,
             Conf(ImgConf(back_size_x=128, back_size_y=128, radius=1000), {}),
         )
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.img
 
     @requires_data(os.path.join(DATAPATH + "/kappa_sigma_clipping",
                                 ("mean_grid_image_206-215-t0002.fits_radius" +

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -10,7 +10,6 @@ from sourcefinder.testutil.decorators import requires_data
 from sourcefinder.testutil.mock import SyntheticImage
 
 import sourcefinder
-from sourcefinder import image as sfimage
 from sourcefinder.image import ImageData
 from sourcefinder.utility.uncertain import Uncertain
 
@@ -35,15 +34,15 @@ class TestNumpySubroutines(unittest.TestCase):
         central_value = a[y, x]  # 34
 
         round_down_to_single_pixel = a[
-            sfimage.ImageData.box_slice_about_pixel(x, y, 0.9)]
+            ImageData.box_slice_about_pixel(x, y, 0.9)]
         self.assertEqual(round_down_to_single_pixel, [[central_value]])
 
-        chunk_3_by_3 = a[sfimage.ImageData.box_slice_about_pixel(x, y, 1)]
+        chunk_3_by_3 = a[ImageData.box_slice_about_pixel(x, y, 1)]
         self.assertEqual(chunk_3_by_3.shape, (3, 3))
         self.assertEqual(central_value, chunk_3_by_3[1, 1])
 
         chunk_3_by_3_round_down = a[
-            sfimage.ImageData.box_slice_about_pixel(x, y, 1.9)]
+            ImageData.box_slice_about_pixel(x, y, 1.9)]
         self.assertListEqual(list(chunk_3_by_3.reshape(9)),
                              list(chunk_3_by_3_round_down.reshape(9))
                              )
@@ -351,10 +350,10 @@ class TestSimpleImageSourceFind(unittest.TestCase):
              4.6760769e+00, 0.0000000e+00,  # error_radius (arcsec), fit_type
              8.3038670e-01, 9.1803038e-01]  # chisq, reduced chisq
 
-        self.image = accessors.sourcefinder_image_from_accessor(
+        image = accessors.sourcefinder_image_from_accessor(
             FitsImage(GRB120422A))
 
-        results = self.image.extract(det=5, anl=3)
+        results = image.extract(det=5, anl=3)
         results = [result.serialize(conf) for result in
                    results]
         self.assertEqual(len(results), 2)
@@ -377,11 +376,11 @@ class TestSimpleImageSourceFind(unittest.TestCase):
         testSingleSourceExtraction(), above). Here we force the lengths of the
         major/minor axes to be held constant when fitting.
         """
-        self.image = accessors.sourcefinder_image_from_accessor(
+        image = accessors.sourcefinder_image_from_accessor(
             FitsImage(GRB120422A))
-        results = self.image.extract(det=5, anl=3, force_beam=True)
-        self.assertEqual(results[0].smaj.value, self.image.beam[0])
-        self.assertEqual(results[0].smin.value, self.image.beam[1])
+        results = image.extract(det=5, anl=3, force_beam=True)
+        self.assertEqual(results[0].smaj.value, image.beam[0])
+        self.assertEqual(results[0].smin.value, image.beam[1])
 
     @requires_data(os.path.join(DATAPATH, 'SWIFT_554620-130504.fits'))
     @requires_data(os.path.join(DATAPATH, 'SWIFT_554620-130504.image'))
@@ -427,9 +426,9 @@ class TestSimpleImageSourceFind(unittest.TestCase):
         source in the image, just by setting the thresholds very high -
         this avoids requiring additional data).
         """
-        self.image = accessors.sourcefinder_image_from_accessor(
+        image = accessors.sourcefinder_image_from_accessor(
             FitsImage(GRB120422A))
-        results = self.image.extract(det=5e10, anl=5e10)
+        results = image.extract(det=5e10, anl=5e10)
         results = [result.serialize() for result in results]
         self.assertEqual(len(results), 0)
 
@@ -450,15 +449,15 @@ class TestMaskedSource(unittest.TestCase):
         Tip of major axis is around 267, 264
         """
 
-        self.image = accessors.sourcefinder_image_from_accessor(
+        image = accessors.sourcefinder_image_from_accessor(
             FitsImage(GRB120422A))
         # FIXME: the line below was in a shadowed method with an identical name
         # self.image.data[250:280, 250:280] = np.ma.masked
-        self.image.data[266:269, 263:266] = np.ma.masked
+        image.data[266:269, 263:266] = np.ma.masked
         # Our modified kappa,sigma clipper gives a slightly lower noise
         # which catches an extra noise peak at the 5 sigma level.
-        self.image.data[42:50, 375:386] = np.ma.masked
-        results = self.image.extract(det=5, anl=3)
+        image.data[42:50, 375:386] = np.ma.masked
+        results = image.extract(det=5, anl=3)
         self.assertFalse(results)
 
 
@@ -469,20 +468,20 @@ class TestMaskedBackground(unittest.TestCase):
         """
         Background at forced fit is masked
         """
-        self.image = accessors.sourcefinder_image_from_accessor(
+        image = accessors.sourcefinder_image_from_accessor(
             accessors.open(os.path.join(DATAPATH, "NCP_sample_image_1.fits")),
             conf=Conf(ImgConf(radius=1.0), {}),
         )
-        result = self.image.fit_to_point(256, 256, 10, 0, None)
+        result = image.fit_to_point(256, 256, 10, 0, None)
         self.assertFalse(result)
 
     @requires_data(os.path.join(DATAPATH, "NCP_sample_image_1.fits"))
     def testMaskedBackgroundBlind(self):
-        self.image = accessors.sourcefinder_image_from_accessor(
+        image = accessors.sourcefinder_image_from_accessor(
             accessors.open(os.path.join(DATAPATH, "NCP_sample_image_1.fits")),
             conf=Conf(ImgConf(radius=1.0), {}),
         )
-        result = self.image.extract(det=10.0, anl=3.0)
+        result = image.extract(det=10.0, anl=3.0)
         self.assertFalse(result)
 
 

--- a/test/test_scripts/test_pyse.py
+++ b/test/test_scripts/test_pyse.py
@@ -1,7 +1,6 @@
 import subprocess
 from pathlib import Path
 
-import pytest
 
 def run_pyse(files, extra_args, out_dir):
     cli_args = ["pyse", *files, "--config-file", "test/data/config.toml"]
@@ -19,73 +18,47 @@ def run_pyse(files, extra_args, out_dir):
             nr_sources_per_image.append(nr_sources)
 
     if len(nr_sources_per_image) != len(files):
-        raise ValueError(f"Not all images finished correctly. Found {len(nr_sources_per_image)} sets of sources with {len(files)} input images. ")
+        raise ValueError(
+            f"Not all images finished correctly. Found {len(nr_sources_per_image)} sets of sources with {len(files)} input images. "
+        )
 
     return nr_sources_per_image
 
-def test_pyse_simple(tmpdir):
-    files = ["test/data/GRB120422A-120429.fits"]
-    extra_args = ["--detection", "6", "--analysis", "5"]
-    nr_sources_per_image = run_pyse(files, extra_args, tmpdir)
 
-    for n in nr_sources_per_image:
-        assert n == 1
-
-@pytest.mark.parametrize("export_arg", [
-    "--skymodel",
-    "--csv",
-    "--regions",
-    "--rmsmap",
-    "--sigmap",
-    "--residuals",
-    "--islands",
-])
-def test_pyse_export(tmpdir, export_arg):
+def test_pyse_export(tmpdir):
     files = ["test/data/GRB120422A-120429.fits"]
-    extra_args = ["--detection", "6", "--analysis", "5", export_arg]
+    export_args = [
+        "--skymodel",
+        "--csv",
+        "--regions",
+        "--rmsmap",
+        "--sigmap",
+        "--residuals",
+        "--islands",
+    ]
+    extra_args = ["--detection", "6", "--analysis", "5", *export_args]
     nr_sources_per_image = run_pyse(files, extra_args, tmpdir)
 
     for n in nr_sources_per_image:
         assert n == 1
 
     # Check CSV
-    if export_arg == "--csv":
-        assert Path(f"{tmpdir}/GRB120422A-120429.csv").exists()
-    else:
-        assert not Path(f"{tmpdir}/GRB120422A-120429.csv").exists()
+    assert Path(f"{tmpdir}/GRB120422A-120429.csv").exists()
 
     # Check skymodel
-    if export_arg == "--skymodel":
-        assert Path(f"{tmpdir}/GRB120422A-120429.skymodel").exists()
-    else:
-        assert not Path(f"{tmpdir}/GRB120422A-120429.skymodel").exists()
+    assert Path(f"{tmpdir}/GRB120422A-120429.skymodel").exists()
 
     # Check regions
-    if export_arg == "--regions":
-        assert Path(f"{tmpdir}/GRB120422A-120429.reg").exists()
-    else:
-        assert not Path(f"{tmpdir}/GRB120422A-120429.reg").exists()
+    assert Path(f"{tmpdir}/GRB120422A-120429.reg").exists()
 
     # Check rmsmap
-    if export_arg == "--rmsmap":
-        assert Path(f"{tmpdir}/GRB120422A-120429.rms.fits").exists()
-    else:
-        assert not Path(f"{tmpdir}/GRB120422A-120429.rms.fits").exists()
+    assert Path(f"{tmpdir}/GRB120422A-120429.rms.fits").exists()
 
     # Check sigmap
-    if export_arg == "--sigmap":
-        assert Path(f"{tmpdir}/GRB120422A-120429.sig.fits").exists()
-    else:
-        assert not Path(f"{tmpdir}/GRB120422A-120429.sig.fits").exists()
+    assert Path(f"{tmpdir}/GRB120422A-120429.sig.fits").exists()
 
     # Check residuals
-    if export_arg == "--residuals":
-        assert Path(f"{tmpdir}/GRB120422A-120429.residuals.fits").exists()
-    else:
-        assert not Path(f"{tmpdir}/GRB120422A-120429.residuals.fits").exists()
+    assert Path(f"{tmpdir}/GRB120422A-120429.residuals.fits").exists()
 
     # Check islands
-    if export_arg == "--islands":
-        assert Path(f"{tmpdir}/GRB120422A-120429.islands.fits").exists()
-    else:
-        assert not Path(f"{tmpdir}/GRB120422A-120429.islands.fits").exists()
+    assert Path(f"{tmpdir}/GRB120422A-120429.islands.fits").exists()


### PR DESCRIPTION
- enable test matrices in pyproject.toml
- tests: remove redundant runs for faster CLI tests
- tests: move common test setup to setUpClass

Almost halve test run time by removing redundant test setups that were
expensive.
