### PR TITLE
Restore consistency in use of hyphens

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -74,7 +74,7 @@ jobs:
           hatch run +py=${{matrix.python-version}} test:pytest
       - name: Integration test
         run: |
-          hatch run pyse --config-file test/data/config.toml --detection_thr \
+          hatch run pyse --config-file test/data/config.toml --detection-thr \
           5 --radius 400 --csv --force-beam test/data/GRB120422A-120429.fits
 
   type-check:

--- a/sourcefinder/utility/cli.py
+++ b/sourcefinder/utility/cli.py
@@ -212,10 +212,10 @@ def construct_argument_parser():
         "--eps-dec", type=float, help="Dec matching tolerance in arcseconds."
     )
     image_group.add_argument(
-        "--detection_thr", type=float, help="Detection threshold"
+        "--detection-thr", type=float, help="Detection threshold"
     )
     image_group.add_argument(
-        "--analysis_thr", type=float, help="Analysis threshold"
+        "--analysis-thr", type=float, help="Analysis threshold"
     )
     image_group.add_argument(
         "--fdr", action="store_true", help="Use False Detection Rate algorithm"

--- a/test/test_scripts/test_pyse.py
+++ b/test/test_scripts/test_pyse.py
@@ -36,7 +36,7 @@ def test_pyse_export(tmpdir):
         "--residuals",
         "--islands",
     ]
-    extra_args = ["--detection_thr", "6", "--analysis_thr", "5", *export_args]
+    extra_args = ["--detection-thr", "6", "--analysis-thr", "5", *export_args]
     nr_sources_per_image = run_pyse(files, extra_args, tmpdir)
 
     for n in nr_sources_per_image:


### PR DESCRIPTION
Restore consistency in use of hyphens instead of underscores for command line arguments.